### PR TITLE
Fix in gradle resource duplication strategy

### DIFF
--- a/newrelic-security-agent/build.gradle
+++ b/newrelic-security-agent/build.gradle
@@ -202,9 +202,10 @@ task newrelicVersionedAgentJar(type: Jar) {
     dependsOn(instrumentProjects().collect { it.tasks["jar"] })
     dependsOn("cyclonedxBom")
 
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+
     from("$rootDir/LICENSE.md")
     from("$rootDir/THIRD_PARTY_NOTICES.md")
-    new File(projectDir, 'src/main/resources/NOTICE')
     from("$buildDir/reports/SBOM.json")
 
     includeEmptyDirs = false

--- a/newrelic-security-api/build.gradle
+++ b/newrelic-security-api/build.gradle
@@ -127,8 +127,7 @@ task newrelicVersionedAPIJar(type: Jar) {
     group("build")
     dependsOn("transformedShadowJar")
 
-    from("$rootDir/LICENSE")
-    from("$rootDir/THIRD_PARTY_NOTICES.md")
+    from("$rootDir/LICENSE.md")
 
     includeEmptyDirs = false
 


### PR DESCRIPTION
Fixes build issues due to duplicate resources due to copy instructions and api lib shadowing. 