### PR TITLE
Update build.gradle

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,10 @@ Noteworthy changes to the agent are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.4-limited-preview] - UPCOMING
+### Changes
+- Limiting the supported version range for Apache log4j due to the new version release of Apache log4j on 21 June 2023
+
 ## [1.0.3-limited-preview] - 2023-05-23
 ### Changes
 - License update

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The agent automatically instruments the following frameworks.
 - JAX-RS 1.0 to latest
 - Spring Boot 1.4 to latest
 - Struts 2.0.5 to latest
-- Log4j from 2.0 to latest
+- Log4j from 2.0 to 2.20.0
 - Servlet from 2.4 to latest
 - Spring from 0 to latest
 

--- a/instrumentation-security/apache-log4j-2.17.2/build.gradle
+++ b/instrumentation-security/apache-log4j-2.17.2/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 }
 
 verifyInstrumentation {
-    passes("org.apache.logging.log4j:log4j-core:[2.17.2,)")
+    passes("org.apache.logging.log4j:log4j-core:[2.17.2,2.20.0]")
 }
 
 site {


### PR DESCRIPTION
Limiting the version range for Apache log4j due to the new version release of Apache log4j on 21 June 2023