### PR TITLE
Update to main branch for APM and use new proprietary jars

### DIFF
--- a/.github/actions/setup-environment-inst-verifier/action.yml
+++ b/.github/actions/setup-environment-inst-verifier/action.yml
@@ -52,7 +52,7 @@ runs:
     - name: Download S3 instrumentation jar zip
       shell: bash
       run: |
-        aws s3 cp s3://nr-java-agent-s3-instrumentation/proprietary-jars-20220805.zip proprietary-jars.zip && unzip proprietary-jars.zip && cp -rf instrumentation/** instrumentation-security/
+        aws s3 cp s3://nr-java-agent-s3-instrumentation/proprietary-jars-20230623.zip proprietary-jars.zip && unzip proprietary-jars.zip && cp -rf instrumentation/** instrumentation-security/
         if [ $? -ne 0 ]; then
           echo "Instrumentation jar zip unavailable." >> $GITHUB_STEP_SUMMARY
         fi

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -8,7 +8,7 @@ inputs:
   apm-branch:
     description: 'The branch of APM source code to use'
     required: true
-    default: 'k2-integration'
+    default: 'main'
   apm-aws-access-key-id:
     description: 'APM AWS S3 access key id'
   apm-aws-secret-access-key:
@@ -103,7 +103,7 @@ runs:
     - name: Download S3 instrumentation jar zip
       shell: bash
       run: |
-        aws s3 cp s3://nr-java-agent-s3-instrumentation/proprietary-jars-20220805.zip proprietary-jars.zip && unzip proprietary-jars.zip && cp -rf instrumentation/** instrumentation-security/ && unzip -d newrelic-java-agent proprietary-jars.zip
+        aws s3 cp s3://nr-java-agent-s3-instrumentation/proprietary-jars-20230623.zip proprietary-jars.zip && unzip proprietary-jars.zip && cp -rf instrumentation/** instrumentation-security/ && unzip -d newrelic-java-agent proprietary-jars.zip
         if [ $? -ne 0 ]; then
           echo "Instrumentation jar zip unavailable." >> $GITHUB_STEP_SUMMARY
         fi

--- a/.github/workflows/X-Reusable-Build-Security-Agent.yml
+++ b/.github/workflows/X-Reusable-Build-Security-Agent.yml
@@ -11,7 +11,7 @@ on:
         description: 'The source-ref of APM source code to use'
         required: true
         type: string
-        default: 'k2-integration'
+        default: 'main'
       run-unit-test:
         description: 'Run instrumentation unit tests ?'
         required: true
@@ -38,7 +38,7 @@ on:
         description: 'The source-ref of APM source code to use'
         required: true
         type: string
-        default: 'k2-integration'
+        default: 'main'
       run-unit-test:
         description: 'Run instrumentation unit tests ?'
         required: true

--- a/.github/workflows/X-Reusable-Build-Security-Agent.yml
+++ b/.github/workflows/X-Reusable-Build-Security-Agent.yml
@@ -74,28 +74,6 @@ jobs:
           apm-aws-secret-access-key: ${{ secrets.APM_AWS_SECRET_ACCESS_KEY }}
           apm-aws-region: us-east-2
 
-      - name: Check version compatibility
-        shell: bash
-        run: |
-          APM_CONFIGURED_CSEC_VERSION=$(./gradlew ${GRADLE_OPTIONS} -p newrelic-java-agent/ properties | grep 'csecCollectorVersion:' | awk -F': ' '{print $2}')
-          CSEC_CONFIGURED_APM_VERSION=$(./gradlew ${GRADLE_OPTIONS} properties | grep 'nrAPIVersion:' | awk -F': ' '{print $2}')
-
-          if [[ "${APM_VERSION}" != "${CSEC_CONFIGURED_APM_VERSION}" ]]
-          then
-            printf "${RED}Version mismatch regarding APM: ${NONE}\n"
-            printf "${RED}Version of APM to build: ${APM_VERSION} ${NONE}\n"
-            printf "${RED}Version of APM API used by CSEC: ${CSEC_CONFIGURED_APM_VERSION} ${NONE}\n"
-            exit 1
-          fi
-
-          if [[ "${SECURITY_VERSION}" != "${APM_CONFIGURED_CSEC_VERSION}" ]]
-          then
-            printf "${RED}Version mismatch regarding Security: ${NONE}\n"
-            printf "${RED}Version of CSEC to build: ${SECURITY_VERSION} ${NONE}\n"
-            printf "${RED}Version of CSEC API used by APM: ${APM_CONFIGURED_CSEC_VERSION} ${NONE}\n"
-            exit 2
-          fi
-
       - name: Publish CSEC to local
         uses: ./.github/actions/publish-csec-local
 

--- a/.github/workflows/build-integrated-jar.yml
+++ b/.github/workflows/build-integrated-jar.yml
@@ -9,7 +9,7 @@ on:
       apm-source-ref:
         description: 'The source-ref of APM source code to use'
         required: true
-        default: 'k2-integration'
+        default: 'main'
       csec-run-unittest:
         description: 'Whether to run CSEC instrumentation unit tests'
         required: true

--- a/.github/workflows/build-integrated-jar.yml
+++ b/.github/workflows/build-integrated-jar.yml
@@ -71,28 +71,6 @@ jobs:
           apm-aws-secret-access-key: ${{ secrets.APM_AWS_SECRET_ACCESS_KEY }}
           apm-aws-region: us-east-2
 
-      - name: Check version compatibility
-        shell: bash
-        run: |
-          APM_CONFIGURED_CSEC_VERSION=$(./gradlew ${GRADLE_OPTIONS} -p newrelic-java-agent/ properties | grep 'csecCollectorVersion:' | awk -F': ' '{print $2}')
-          CSEC_CONFIGURED_APM_VERSION=$(./gradlew ${GRADLE_OPTIONS} properties | grep 'nrAPIVersion:' | awk -F': ' '{print $2}')
-          
-          if [[ "${APM_VERSION}" != "${CSEC_CONFIGURED_APM_VERSION}" ]]
-          then
-            printf "${RED}Version mismatch regarding APM: ${NONE}\n"
-            printf "${RED}Version of APM to build: ${APM_VERSION} ${NONE}\n"
-            printf "${RED}Version of APM API used by CSEC: ${CSEC_CONFIGURED_APM_VERSION} ${NONE}\n"
-            exit 1
-          fi
-          
-          if [[ "${SECURITY_VERSION}" != "${APM_CONFIGURED_CSEC_VERSION}" ]]
-          then
-            printf "${RED}Version mismatch regarding Security: ${NONE}\n"
-            printf "${RED}Version of CSEC to build: ${SECURITY_VERSION} ${NONE}\n"
-            printf "${RED}Version of CSEC API used by APM: ${APM_CONFIGURED_CSEC_VERSION} ${NONE}\n"
-            exit 2
-          fi
-
       - name: Build Integrated Agent Jar
         uses: ./.github/actions/build-apm-jar
 

--- a/.github/workflows/publish-main-snapshot-to-maven.yml
+++ b/.github/workflows/publish-main-snapshot-to-maven.yml
@@ -10,7 +10,7 @@ jobs:
     secrets: inherit
     with:
       apm-repo: 'newrelic/newrelic-java-agent'
-      apm-source-ref: 'k2-integration'
+      apm-source-ref: 'main'
       csec-run-unittest: 'true'
       csec-run-instrumentation-verify: 'true'
       is-release: 'false'

--- a/.github/workflows/publish-release-to-maven.yml
+++ b/.github/workflows/publish-release-to-maven.yml
@@ -11,7 +11,7 @@ jobs:
     secrets: inherit
     with:
       apm-repo: 'newrelic/newrelic-java-agent'
-      apm-source-ref: 'k2-integration'
+      apm-source-ref: 'main'
       csec-run-unittest: 'true'
       csec-run-instrumentation-verify: 'true'
       is-release: 'true'

--- a/.github/workflows/publish-to-maven.yml
+++ b/.github/workflows/publish-to-maven.yml
@@ -108,28 +108,6 @@ jobs:
           is-release: ${{ inputs.is-release }}
           version-suffix: ${{ inputs.version-suffix }}
 
-      - name: Check version compatibility
-        shell: bash
-        run: |
-          APM_CONFIGURED_CSEC_VERSION=$(./gradlew ${GRADLE_OPTIONS} -p newrelic-java-agent/ properties | grep 'csecCollectorVersion:' | awk -F': ' '{print $2}')
-          CSEC_CONFIGURED_APM_VERSION=$(./gradlew ${GRADLE_OPTIONS} properties | grep 'nrAPIVersion:' | awk -F': ' '{print $2}')
-
-          if [[ "${APM_VERSION}" != "${CSEC_CONFIGURED_APM_VERSION}" ]]
-          then
-            printf "${RED}Version mismatch regarding APM: ${NONE}\n"
-            printf "${RED}Version of APM to build: ${APM_VERSION} ${NONE}\n"
-            printf "${RED}Version of APM API used by CSEC: ${CSEC_CONFIGURED_APM_VERSION} ${NONE}\n"
-            exit 1
-          fi
-
-          if [[ "${SECURITY_VERSION}" != "${APM_CONFIGURED_CSEC_VERSION}" ]]
-          then
-            printf "${RED}Version mismatch regarding Security: ${NONE}\n"
-            printf "${RED}Version of CSEC to build: ${SECURITY_VERSION} ${NONE}\n"
-            printf "${RED}Version of CSEC API used by APM: ${APM_CONFIGURED_CSEC_VERSION} ${NONE}\n"
-            exit 2
-          fi
-
       - name: Publish CSEC agent API
         shell: bash
         run: ./gradlew ${GRADLE_OPTIONS} :newrelic-security-api:publish -PbuildNumber=${{ github.run_id }}-${{ github.run_number }} -PcommitId=${{ github.sha }} --parallel

--- a/.github/workflows/publish-to-maven.yml
+++ b/.github/workflows/publish-to-maven.yml
@@ -9,7 +9,7 @@ on:
       apm-source-ref:
         description: 'The source-ref of APM source code to use'
         required: true
-        default: 'k2-integration'
+        default: 'main'
       csec-run-unittest:
         description: 'Whether to run CSEC instrumentation unit tests'
         required: true
@@ -41,7 +41,7 @@ on:
         description: 'The source-ref of APM source code to use'
         required: true
         type: string
-        default: 'k2-integration'
+        default: 'main'
       csec-run-unittest:
         description: 'Whether to run CSEC instrumentation unit tests'
         required: true


### PR DESCRIPTION
Using main branch for APM instead of k2-integration
Update the proprietary jars to proprietary-jars-20230623.zip