### PR TITLE
[FIX] netty server issues

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,12 +2,12 @@
 agentVersion=1.0.5
 jsonVersion=1.1.0
 # Updated exposed NR APM API version.
-nrAPIVersion=8.3.0
+nrAPIVersion=8.4.0
 
 # Actual NR APM Agent version
 # This is intentionally kept to an older NR agent version since it is only used as dependency for unit test framework &
 # verify instrumentation plugin. This will only be updated when either of these functions require the update.
-nrAgentVersion=8.3.0
+nrAgentVersion=8.4.0
 #org.gradle.jvmargs=-Xmx2048m
 org.gradle.jvmargs=-Xmx4g
 org.gradle.caching=true

--- a/instrumentation-security/netty-4.0.0/src/main/java/security/io/netty400/channel/ChannelInboundHandler_Instrumentation.java
+++ b/instrumentation-security/netty-4.0.0/src/main/java/security/io/netty400/channel/ChannelInboundHandler_Instrumentation.java
@@ -29,7 +29,9 @@ public abstract class ChannelInboundHandler_Instrumentation {
         try {
             Weaver.callOriginal();
         } finally {
-            NettyUtils.releaseNettyLock();
+            if (isLockAcquired) {
+                NettyUtils.releaseNettyLock();
+            }
         }
     }
 }

--- a/instrumentation-security/netty-4.0.0/src/main/java/security/io/netty400/channel/ChannelInboundHandler_Instrumentation.java
+++ b/instrumentation-security/netty-4.0.0/src/main/java/security/io/netty400/channel/ChannelInboundHandler_Instrumentation.java
@@ -19,10 +19,17 @@ import security.io.netty400.utils.NettyUtils;
 public abstract class ChannelInboundHandler_Instrumentation {
 
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-        NettyUtils.processSecurityRequest(ctx, msg, getClass().getName());
-        if (!StringUtils.startsWith(getClass().getName(), NettyUtils.IO_NETTY)) {
-            ServletHelper.registerUserLevelCode(NettyUtils.IO_NETTY);
+        boolean isLockAcquired = NettyUtils.acquireNettyLockIfPossible();
+        if (isLockAcquired) {
+            NettyUtils.processSecurityRequest(ctx, msg, getClass().getName());
+            if (!StringUtils.startsWith(getClass().getName(), NettyUtils.IO_NETTY)) {
+                ServletHelper.registerUserLevelCode(NettyUtils.IO_NETTY);
+            }
         }
-        Weaver.callOriginal();
+        try {
+            Weaver.callOriginal();
+        } finally {
+            NettyUtils.releaseNettyLock();
+        }
     }
 }

--- a/instrumentation-security/netty-4.0.0/src/main/java/security/io/netty400/channel/ChannelOutboundHandler_Instrumentation.java
+++ b/instrumentation-security/netty-4.0.0/src/main/java/security/io/netty400/channel/ChannelOutboundHandler_Instrumentation.java
@@ -26,7 +26,9 @@ public abstract class ChannelOutboundHandler_Instrumentation {
         try {
             Weaver.callOriginal();
         } finally {
-            NettyUtils.releaseNettyLock();
+            if (isLockAcquired) {
+                NettyUtils.releaseNettyLock();
+            }
         }
     }
 }

--- a/instrumentation-security/netty-4.0.0/src/main/java/security/io/netty400/utils/NettyUtils.java
+++ b/instrumentation-security/netty-4.0.0/src/main/java/security/io/netty400/utils/NettyUtils.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 public class NettyUtils {
     public static String NR_SEC_CUSTOM_ATTRIB_NAME = "NETTY-4.8-REQ-BODY-TRACKER";
+    public static String NR_SEC_NETTY_OPERATIONAL_LOCK = "NR_SEC_NETTY_OPERATIONAL_LOCK";
     private static final String X_FORWARDED_FOR = "x-forwarded-for";
     private static final String EMPTY = "";
     public static final String WRITE_METHOD_NAME = "write";
@@ -207,5 +208,36 @@ public class NettyUtils {
             String headerValue = entry.getValue();
             securityResponse.getHeaders().put(headerKey, headerValue);
         }
+    }
+
+    public static boolean isNettyLockAcquired() {
+        try {
+            return NewRelicSecurity.isHookProcessingActive() &&
+                    Boolean.TRUE.equals(NewRelicSecurity.getAgent().getSecurityMetaData().getCustomAttribute(getNrSecOperationalLockName(), Boolean.class));
+        } catch (Throwable ignored) {}
+        return false;
+    }
+
+    public static boolean acquireNettyLockIfPossible() {
+        try {
+            if (NewRelicSecurity.isHookProcessingActive() &&
+                    !isNettyLockAcquired()) {
+                NewRelicSecurity.getAgent().getSecurityMetaData().addCustomAttribute(getNrSecOperationalLockName(), true);
+                return true;
+            }
+        } catch (Throwable ignored){}
+        return false;
+    }
+
+    public static void releaseNettyLock() {
+        try {
+            if(NewRelicSecurity.isHookProcessingActive()) {
+                NewRelicSecurity.getAgent().getSecurityMetaData().addCustomAttribute(getNrSecOperationalLockName(), null);
+            }
+        } catch (Throwable ignored){}
+    }
+
+    private static String getNrSecOperationalLockName() {
+        return NR_SEC_NETTY_OPERATIONAL_LOCK + Thread.currentThread().getId();
     }
 }

--- a/instrumentation-security/netty-4.0.0/src/test/java/com/nr/agent/security/instrumentation/netty400/NettyTest.java
+++ b/instrumentation-security/netty-4.0.0/src/test/java/com/nr/agent/security/instrumentation/netty400/NettyTest.java
@@ -1,4 +1,4 @@
-package com.nr.security.instrumentation.netty400;
+package com.nr.agent.security.instrumentation.netty400;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;


### PR DESCRIPTION
> Added operational lock to hooked method to avoid reading request/response data multiple times
> Updated nr agent version to 8.4.0 as a fix to failing pre-condition in netty server instrumentation (in test env)