### PR TITLE
Fix ClassNotFoundException for IOStreamHelper

### DIFF
--- a/instrumentation-security/java-io-stream/src/main/java/java/io/BufferedReader_Instrumentation.java
+++ b/instrumentation-security/java-io-stream/src/main/java/java/io/BufferedReader_Instrumentation.java
@@ -13,7 +13,7 @@ import com.newrelic.api.agent.weaver.MatchType;
 import com.newrelic.api.agent.weaver.Weave;
 import com.newrelic.api.agent.weaver.WeaveAllConstructors;
 import com.newrelic.api.agent.weaver.Weaver;
-import com.newrelic.agent.security.instrumentation.inputstream.IOStreamHelper;
+import com.newrelic.api.agent.security.instrumentation.helpers.IOStreamHelper;
 
 @Weave(type = MatchType.BaseClass, originalName = "java.io.BufferedReader")
 public abstract class BufferedReader_Instrumentation {

--- a/instrumentation-security/java-io-stream/src/main/java/java/io/OutputStream_Instrumentation.java
+++ b/instrumentation-security/java-io-stream/src/main/java/java/io/OutputStream_Instrumentation.java
@@ -11,7 +11,7 @@ import com.newrelic.api.agent.security.instrumentation.helpers.GenericHelper;
 import com.newrelic.api.agent.weaver.MatchType;
 import com.newrelic.api.agent.weaver.Weave;
 import com.newrelic.api.agent.weaver.Weaver;
-import com.newrelic.agent.security.instrumentation.inputstream.IOStreamHelper;
+import com.newrelic.api.agent.security.instrumentation.helpers.IOStreamHelper;
 
 @Weave(type = MatchType.BaseClass, originalName = "java.io.OutputStream")
 public abstract class OutputStream_Instrumentation {

--- a/instrumentation-security/java-io-stream/src/main/java/java/io/PrintWriter_Instrumentation.java
+++ b/instrumentation-security/java-io-stream/src/main/java/java/io/PrintWriter_Instrumentation.java
@@ -10,7 +10,7 @@ package java.io;
 import com.newrelic.api.agent.security.NewRelicSecurity;
 import com.newrelic.api.agent.security.instrumentation.helpers.GenericHelper;
 import com.newrelic.api.agent.weaver.*;
-import com.newrelic.agent.security.instrumentation.inputstream.IOStreamHelper;
+import com.newrelic.api.agent.security.instrumentation.helpers.IOStreamHelper;
 
 import java.util.Locale;
 

--- a/instrumentation-security/java-io-stream/src/main/java/java/io/Reader_Instrumentation.java
+++ b/instrumentation-security/java-io-stream/src/main/java/java/io/Reader_Instrumentation.java
@@ -12,7 +12,7 @@ import com.newrelic.api.agent.security.instrumentation.helpers.GenericHelper;
 import com.newrelic.api.agent.weaver.MatchType;
 import com.newrelic.api.agent.weaver.Weave;
 import com.newrelic.api.agent.weaver.Weaver;
-import com.newrelic.agent.security.instrumentation.inputstream.IOStreamHelper;
+import com.newrelic.api.agent.security.instrumentation.helpers.IOStreamHelper;
 
 @Weave(type = MatchType.BaseClass, originalName = "java.io.Reader")
 public abstract class Reader_Instrumentation {

--- a/newrelic-security-agent/src/main/java/com/newrelic/agent/security/intcodeagent/schedulers/SchedulerHelper.java
+++ b/newrelic-security-agent/src/main/java/com/newrelic/agent/security/intcodeagent/schedulers/SchedulerHelper.java
@@ -1,7 +1,11 @@
 package com.newrelic.agent.security.intcodeagent.schedulers;
 
 import com.newrelic.agent.security.intcodeagent.filelogging.FileLoggerThreadPool;
+import com.newrelic.agent.security.intcodeagent.filelogging.LogFileHelper;
+import com.newrelic.agent.security.intcodeagent.filelogging.LogLevel;
 import com.newrelic.agent.security.intcodeagent.logging.IAgentConstants;
+import com.newrelic.agent.security.util.IUtilConstants;
+import com.newrelic.api.agent.NewRelic;
 
 import java.util.Map;
 import java.util.concurrent.*;
@@ -61,6 +65,17 @@ public class SchedulerHelper {
         ScheduledFuture<?> future = commonExecutor.scheduleWithFixedDelay(command, initialDelay, period, unit);
         scheduledFutureMap.put("low-severity-hook-filter-cleanup", future);
         return future;
+    }
+
+    public ScheduledFuture<?> scheduleDailyLogRollover(Runnable command) {
+        logger.log(LogLevel.INFO, "Start ", SchedulerHelper.class.getName());
+        if(LogFileHelper.isDailyRollover()) {
+            int period = NewRelic.getAgent().getConfig().getValue(IUtilConstants.NR_LOG_DAILY_ROLLOVER_PERIOD, 24);
+            ScheduledFuture<?> future = commonExecutor.scheduleWithFixedDelay(command, period, period, TimeUnit.HOURS);
+            scheduledFutureMap.put("daily-log-rollover", future);
+            return future;
+        }
+        return null;
     }
 
 }

--- a/newrelic-security-api/src/main/java/com/newrelic/api/agent/security/instrumentation/helpers/IOStreamHelper.java
+++ b/newrelic-security-api/src/main/java/com/newrelic/api/agent/security/instrumentation/helpers/IOStreamHelper.java
@@ -1,4 +1,4 @@
-package com.newrelic.agent.security.instrumentation.inputstream;
+package com.newrelic.api.agent.security.instrumentation.helpers;
 
 import com.newrelic.api.agent.security.NewRelicSecurity;
 import com.newrelic.api.agent.security.instrumentation.helpers.GenericHelper;


### PR DESCRIPTION
moved the helper class to api under helpers package 'com.newrelic.api.agent.security.instrumentation.helpers'