### PR TITLE
Fix for NR-234390

### DIFF
--- a/newrelic-security-api/src/main/java/com/newrelic/api/agent/security/instrumentation/helpers/URLMappingsHelper.java
+++ b/newrelic-security-api/src/main/java/com/newrelic/api/agent/security/instrumentation/helpers/URLMappingsHelper.java
@@ -2,17 +2,27 @@ package com.newrelic.api.agent.security.instrumentation.helpers;
 
 import com.newrelic.api.agent.security.schema.ApplicationURLMapping;
 
+import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class URLMappingsHelper {
     private static Set<ApplicationURLMapping> mappings = ConcurrentHashMap.newKeySet();
+    private static final Set<String> defaultHandlers = new HashSet<String>() {{
+        add("org.eclipse.jetty.jsp.JettyJspServlet");
+        add("org.eclipse.jetty.servlet.ServletHandler$Default404Servlet");
+        add("org.glassfish.jersey.servlet.ServletContainer");
+        add("org.apache.jasper.servlet.JspServlet");
+        add("org.apache.catalina.servlets.DefaultServlet");
+    }};
 
     public static Set<ApplicationURLMapping> getApplicationURLMappings() {
         return mappings;
     }
 
     public static void addApplicationURLMapping(ApplicationURLMapping mapping) {
-        mappings.add(mapping);
+        if (mapping.getHandler() == null || (mapping.getHandler() != null && !defaultHandlers.contains(mapping.getHandler()))) {
+            mappings.add(mapping);
+        }
     }
 }


### PR DESCRIPTION
These false APIs detecting, as they are framework/server specific handlers. Since these are not user defined handlers, we are not aiming to detect these API endpoints. 
To address this added logic to filter out the default framework/server specific handlers.