### PR TITLE
[NR-249812] Support For Netty Reactor Server

### DIFF
--- a/newrelic-security-agent/src/main/java/com/newrelic/api/agent/security/Agent.java
+++ b/newrelic-security-agent/src/main/java/com/newrelic/api/agent/security/Agent.java
@@ -351,7 +351,7 @@ public class Agent implements SecurityAgent {
     private static boolean checkIfNRGeneratedEvent(AbstractOperation operation) {
         boolean isNettyReactor = false, isNRGeneratedEvent = false;
         for (int i = 1, j = 0; i < operation.getStackTrace().length; i++) {
-            if(!isNettyReactor && StringUtils.equalsAny(operation.getStackTrace()[i].getClassName(), "com.nr.instrumentation.TokenLinkingSubscriber", "com.nr.instrumentation.reactor.netty.TokenLinkingSubscriber")){
+            if(StringUtils.equalsAny(operation.getStackTrace()[i].getClassName(), "com.nr.instrumentation.TokenLinkingSubscriber", "com.nr.instrumentation.reactor.netty.TokenLinkingSubscriber")){
                 isNettyReactor = true;
                 continue;
             }


### PR DESCRIPTION
Resolved issue regarding the absence of event generation for Netty Reactor Server. As a result, the CSEC Java Agent now supports Netty Reactor Server.