### PR TITLE
Handle InvalidPathException thrown by Paths.get method

### DIFF
--- a/newrelic-security-agent/src/main/java/com/newrelic/agent/security/intcodeagent/schedulers/FileCleaner.java
+++ b/newrelic-security-agent/src/main/java/com/newrelic/agent/security/intcodeagent/schedulers/FileCleaner.java
@@ -12,6 +12,7 @@ import org.apache.commons.io.filefilter.DirectoryFileFilter;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.concurrent.ScheduledFuture;
@@ -45,7 +46,7 @@ public class FileCleaner {
                     if(age > 0){
                         FileUtils.deleteQuietly(new File(file));
                     }
-                } catch (IOException e) {
+                } catch (IOException | InvalidPathException e) {
                 }
             }
         }

--- a/newrelic-security-api/src/main/java/com/newrelic/api/agent/security/instrumentation/helpers/FileHelper.java
+++ b/newrelic-security-api/src/main/java/com/newrelic/api/agent/security/instrumentation/helpers/FileHelper.java
@@ -7,6 +7,7 @@ import com.newrelic.api.agent.security.schema.operation.FileIntegrityOperation;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFileAttributes;
 import java.nio.file.attribute.PosixFilePermission;
@@ -113,7 +114,7 @@ public class FileHelper {
                             Set<PosixFilePermission> permissionSet = fileAttributes.permissions();
                             permissions = permissionSet.toString();
                         }
-                    } catch (IOException e) {
+                    } catch (IOException | InvalidPathException e) {
                     }
                     long fileLength = file.length();
                     FileIntegrityOperation fbean = new FileIntegrityOperation(file.exists(), fileName, className,
@@ -123,7 +124,8 @@ public class FileHelper {
                     return fbean;
                 }
             }
-        } finally {
+        } catch (InvalidPathException ignored){}
+        finally {
             if(lockAcquired){
                 ThreadLocalLockHelper.releaseLock();
             }
@@ -137,15 +139,17 @@ public class FileHelper {
         try {
             if(lockAcquired) {
                 for (String fileName : fileNames) {
-                    File file = Paths.get(fileName).toFile();
-                    if(NewRelicSecurity.getAgent().getSecurityMetaData().getFileLocalMap().containsKey(fileName)){
-                        FileIntegrityOperation fbean = NewRelicSecurity.getAgent().getSecurityMetaData().getFileLocalMap().get(fileName);
-                        if(fbean.isIntegrityBreached(file)){
-                            //Lock release is required here, as this register operation inside lock is intentional
-                            ThreadLocalLockHelper.releaseLock();
-                            NewRelicSecurity.getAgent().registerOperation(fbean);
+                    try {
+                        File file = Paths.get(fileName).toFile();
+                        if (NewRelicSecurity.getAgent().getSecurityMetaData().getFileLocalMap().containsKey(fileName)) {
+                            FileIntegrityOperation fbean = NewRelicSecurity.getAgent().getSecurityMetaData().getFileLocalMap().get(fileName);
+                            if (fbean.isIntegrityBreached(file)) {
+                                //Lock release is required here, as this register operation inside lock is intentional
+                                ThreadLocalLockHelper.releaseLock();
+                                NewRelicSecurity.getAgent().registerOperation(fbean);
+                            }
                         }
-                    }
+                    } catch (InvalidPathException ignored) {}
                 }
             }
         } finally {

--- a/newrelic-security-api/src/main/java/com/newrelic/api/agent/security/instrumentation/helpers/ServletHelper.java
+++ b/newrelic-security-api/src/main/java/com/newrelic/api/agent/security/instrumentation/helpers/ServletHelper.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -110,7 +111,6 @@ public class ServletHelper {
                         }
                         tmpFile = StringUtils.replace(tmpFile, NR_CSEC_VALIDATOR_HOME_TMP,
                                 NewRelicSecurity.getAgent().getAgentTempDir());
-                        k2RequestIdentifierInstance.getTempFiles().add(tmpFile);
                         boolean lockAcquired = ThreadLocalLockHelper.acquireLock();
                         try {
                             if (lockAcquired) {
@@ -126,9 +126,11 @@ public class ServletHelper {
                                 }
                                 if (!fileToCreate.exists()) {
                                     Files.createFile(fileToCreate.toPath());
+                                    k2RequestIdentifierInstance.getTempFiles().add(tmpFile);
                                 }
                             }
-                        } catch (Throwable e) {
+                        } catch (IOException | InvalidPathException ignored) {}
+                        catch (Throwable e) {
                             String message = "Error while parsing fuzz request : %s";
                             NewRelicSecurity.getAgent().log(LogLevel.INFO, String.format(message, e.getMessage()), e, ServletHelper.class.getName());
                         } finally {
@@ -207,7 +209,7 @@ public class ServletHelper {
                 for (String file : files) {
                     try {
                         Files.deleteIfExists(Paths.get(file));
-                    } catch (IOException e) {
+                    } catch (IOException | InvalidPathException e) {
                     }
                 }
             }

--- a/newrelic-security-api/src/main/java/com/newrelic/api/agent/security/schema/operation/FileIntegrityOperation.java
+++ b/newrelic-security-api/src/main/java/com/newrelic/api/agent/security/schema/operation/FileIntegrityOperation.java
@@ -8,6 +8,7 @@ import com.newrelic.api.agent.security.schema.VulnerabilityCaseType;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFileAttributes;
 import java.nio.file.attribute.PosixFilePermission;
@@ -155,7 +156,7 @@ public class FileIntegrityOperation extends AbstractOperation {
                 permissions = permissionSet.toString();
             }
             return (exists != this.exists || lastModified != this.lastModified || !StringUtils.equals(permissions, this.permissionString) || length != this.length);
-        } catch (IOException e) {
+        } catch (IOException | InvalidPathException e) {
         }
         return false;
     }


### PR DESCRIPTION
Implemented a fix by ensuring proper handling of the InvalidPathException wherever the Paths.get method was utilized within the codebase. 