### PR TITLE
Upgrade Log file size and count handling

### DIFF
--- a/newrelic-security-agent/src/main/java/com/newrelic/agent/security/intcodeagent/filelogging/FileLoggerThreadPool.java
+++ b/newrelic-security-agent/src/main/java/com/newrelic/agent/security/intcodeagent/filelogging/FileLoggerThreadPool.java
@@ -20,7 +20,7 @@ public class FileLoggerThreadPool {
 
     private boolean isInitLoggingActive = true;
 
-    protected final int maxfilesize;
+    protected final long maxfilesize;
 
     protected final int maxfiles;
 
@@ -32,8 +32,8 @@ public class FileLoggerThreadPool {
         int maxPoolSize = 1;
         int corePoolSize = 1;
         long keepAliveTime = 600;
-        maxfiles = Math.max(K2JALogProperties.maxfiles, LogFileHelper.logFileCount());
-        maxfilesize = LogFileHelper.logFileLimit()*1024;
+        maxfiles = LogFileHelper.logFileCount();
+        maxfilesize = LogFileHelper.logFileLimit()* 1024L;
 
         TimeUnit timeUnit = TimeUnit.SECONDS;
 

--- a/newrelic-security-agent/src/main/java/com/newrelic/agent/security/intcodeagent/filelogging/InitLogWriter.java
+++ b/newrelic-security-agent/src/main/java/com/newrelic/agent/security/intcodeagent/filelogging/InitLogWriter.java
@@ -178,7 +178,9 @@ public class InitLogWriter implements Runnable {
             FileLoggerThreadPool.getInstance().setInitLoggingActive(true);
 
 //			writer.newLine();
-            rollover(currentLogFileName);
+            if(maxFileSize > 0) {
+                rollover(currentLogFileName);
+            }
         } catch (IOException e) {
             //TODO report to cloud
             FileLoggerThreadPool.getInstance().setInitLoggingActive(false);

--- a/newrelic-security-agent/src/main/java/com/newrelic/agent/security/intcodeagent/filelogging/LogFileHelper.java
+++ b/newrelic-security-agent/src/main/java/com/newrelic/agent/security/intcodeagent/filelogging/LogFileHelper.java
@@ -37,12 +37,13 @@ public class LogFileHelper {
 
     public static final String LOG_LIMIT = "log_limit_in_kbytes";
     public static final boolean DEFAULT_LOG_DAILY = false;
-    public static final int DEFAULT_LOG_FILE_COUNT = 1;
+    public static final Integer DEFAULT_LOG_FILE_COUNT = 1;
     public static final String DEFAULT_LOG_FILE_NAME = "java-security-collector.log";
 
     public static final String STDOUT = "STDOUT";
 
     private static final String STRING_DOT = ".";
+    private static final Integer DEFAULT_LOG_FILE_LIMIT = 0;
 
     public static boolean isLoggingToStdOut() {
         String logFileName = NewRelic.getAgent().getConfig().getValue(LogFileHelper.LOG_FILE_NAME, LogFileHelper.DEFAULT_LOG_FILE_NAME);
@@ -50,19 +51,26 @@ public class LogFileHelper {
     }
 
     public static int logFileCount() {
-        return Math.max(1, NewRelic.getAgent().getConfig().getValue(LogFileHelper.LOG_FILE_COUNT, LogFileHelper.DEFAULT_LOG_FILE_COUNT));
+        try {
+            return NewRelic.getAgent().getConfig().getValue(LogFileHelper.LOG_FILE_COUNT, LogFileHelper.DEFAULT_LOG_FILE_COUNT);
+        } catch (Exception e) {
+            return LogFileHelper.DEFAULT_LOG_FILE_COUNT;
+        }
     }
 
     public static int logFileLimit() {
-        int size = NewRelic.getAgent().getConfig().getValue(LogFileHelper.LOG_LIMIT, 1);
-        return size>1?size: K2JALogProperties.maxfilesize;
+        try {
+            return NewRelic.getAgent().getConfig().getValue(LogFileHelper.LOG_LIMIT, DEFAULT_LOG_FILE_LIMIT);
+        } catch (Exception e) {
+            return DEFAULT_LOG_FILE_LIMIT;
+        }
     }
 
     public static boolean isDailyRollover() {
         return NewRelic.getAgent().getConfig().getValue(LogFileHelper.LOG_DAILY, LogFileHelper.DEFAULT_LOG_DAILY);
     }
 
-    public static void deleteRolloverLogFiles(String fileName, int max) {
+    public static void deleteRolloverLogFiles(String fileName, long max) {
         Collection<File> rolloverLogFiles = FileUtils.listFiles(new File(OsVariablesInstance.getInstance().getOsVariables().getLogDirectory()), FileFilterUtils.prefixFileFilter(fileName + "."), null);
 
         if (rolloverLogFiles.size() > max) {

--- a/newrelic-security-agent/src/main/java/com/newrelic/agent/security/intcodeagent/filelogging/LogWriter.java
+++ b/newrelic-security-agent/src/main/java/com/newrelic/agent/security/intcodeagent/filelogging/LogWriter.java
@@ -178,7 +178,9 @@ public class LogWriter implements Runnable {
             FileLoggerThreadPool.getInstance().setLoggingActive(true);
 
 //			writer.newLine();
-            rollover(currentLogFileName);
+            if(maxFileSize > 0){
+                rollover(currentLogFileName);
+            }
         } catch (IOException e) {
             if (FileLoggerThreadPool.getInstance().isLoggingActive()) {
                 //TODO report to cloud


### PR DESCRIPTION
the order of precedence and explanation for configuration variables affecting log rotation.

- If `log_daily` is true:

1. A **log_limit_in_kbytes** value greater than zero will result in a composite triggering policy, where logs will roll once per day or when the defined size is reached, retaining up to log_file_count files
2. A **log_limit_in_kbytes** value of zero will result in logs rolling once per day retaining up to log_file_count files

- If `log_daily` is false and **log_limit_in_kbytes** > 0, a sized based policy will be configured, where logs will roll when the defined size is reached, retaining up to log_file_count files

- If `log_daily` is false and **log_limit_in_kbytes** = 0, no log file rolling logic will be configured