### PR TITLE
Support Authentication capabilities for Proxy Settings

### DIFF
--- a/newrelic-security-agent/src/main/java/com/newrelic/agent/security/intcodeagent/websocket/WSClient.java
+++ b/newrelic-security-agent/src/main/java/com/newrelic/agent/security/intcodeagent/websocket/WSClient.java
@@ -188,6 +188,7 @@ public class WSClient extends WebSocketClient {
                  */
                 // Requires System.setProperty("jdk.http.auth.tunneling.disabledSchemes", ""); reference https://github.com/TooTallNate/Java-WebSocket/issues/1179#issuecomment-2184917604
                 System.setProperty("jdk.http.auth.tunneling.disabledSchemes", "");
+                System.setProperty("jdk.http.auth.proxying.disabledSchemes", "");
                 Authenticator.setDefault(new Authenticator() {
                     @Override
                     protected PasswordAuthentication getPasswordAuthentication() {

--- a/newrelic-security-agent/src/main/java/com/newrelic/agent/security/intcodeagent/websocket/WSClient.java
+++ b/newrelic-security-agent/src/main/java/com/newrelic/agent/security/intcodeagent/websocket/WSClient.java
@@ -181,16 +181,20 @@ public class WSClient extends WebSocketClient {
             Proxy proxy = new Proxy(getProxyScheme(proxyScheme), new InetSocketAddress(proxyHost, proxyPort));
 
             if (proxyUser != null && proxyPass != null) {
-                // This Sets the authenticator that will be used by
-                // the networking code when a proxy or an HTTP server asks for authentication.
-                // This can lead to potential leak of authentication info by the application itself.
-//                Authenticator.setDefault(new Authenticator() {
-//                    @Override
-//                    protected PasswordAuthentication getPasswordAuthentication() {
-//                        return new PasswordAuthentication(proxyUser, proxyPass.toCharArray());
-//                    }
-//                });
-//                logger.log(LogLevel.FINER, "Authenticated proxy using username and password", WSClient.class.getName());
+                /**
+                 * This Sets the authenticator that will be used by
+                 * the networking code when a proxy or an HTTP server asks for authentication.
+                 * This can lead to potential leak of authentication info by the application itself.
+                 */
+                // Requires System.setProperty("jdk.http.auth.tunneling.disabledSchemes", ""); reference https://github.com/TooTallNate/Java-WebSocket/issues/1179#issuecomment-2184917604
+                System.setProperty("jdk.http.auth.tunneling.disabledSchemes", "");
+                Authenticator.setDefault(new Authenticator() {
+                    @Override
+                    protected PasswordAuthentication getPasswordAuthentication() {
+                        return new PasswordAuthentication(proxyUser, proxyPass.toCharArray());
+                    }
+                });
+                logger.log(LogLevel.FINER, "Authenticated proxy using username and password", WSClient.class.getName());
             }
             logger.log(LogLevel.FINER, String.format("Proxy being used to connect with WSS %s", proxy), WSClient.class.getName());
             return proxy;


### PR DESCRIPTION
Default Auth mechanism requires setting of property jdk.http.auth.tunneling.disabledSchemes