### PR TITLE
using v4 of the artifact actions

### DIFF
--- a/.github/actions/build-apm-jar/action.yml
+++ b/.github/actions/build-apm-jar/action.yml
@@ -13,7 +13,7 @@ runs:
         cd ..
 
     - name: Capture custom jar
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: newrelic-artifact
         path: |


### PR DESCRIPTION
Starting January 30th, 2025 Deprecation notice: v3 of the artifact actions
We will be using V4