### PR TITLE
Fix verifier error for Apache Struts 2 and Solr

### DIFF
--- a/instrumentation-security/apache-struts2/build.gradle
+++ b/instrumentation-security/apache-struts2/build.gradle
@@ -11,7 +11,7 @@ jar {
 }
 
 verifyInstrumentation {
-    passesOnly 'org.apache.struts:struts2-core:[2.1.2,)'
+    passesOnly 'org.apache.struts:struts2-core:[2.1.2,7.0.0)'
     excludeRegex 'org.apache.struts:struts2-core:2.3.15.1-atlassian-[4-5]$'
 }
 

--- a/instrumentation-security/solr-9.0.0/build.gradle
+++ b/instrumentation-security/solr-9.0.0/build.gradle
@@ -36,7 +36,7 @@ test {
 }
 
 verifyInstrumentation {
-    passesOnly 'org.apache.solr:solr-core:[9.0.0,)'
+    passesOnly 'org.apache.solr:solr-core:[9.0.0,9.8.0)'
     exclude 'org.apache.solr:solr-core:[8.0.0,9.0.0)'
     excludeRegex 'org.apache.solr:solr-core:.*(ALPHA|BETA)+$'
 }


### PR DESCRIPTION
- Limiting instrumentation support in Apache Struts 2, to support the new version 7.0.0 released on Dec 11, 2024.
- Limiting instrumentation support in Apache Solr, to support the new version 9.8.0 released on Jan 21, 2025.