### PR TITLE
Java Security Agent Version 1.6.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,19 @@ Noteworthy changes to the agent are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] - 2025-3-1
+### Adds
+- [PR-309](https://github.com/newrelic/csec-java-agent/pull/309) Introduced API Endpoint detection for Resin Server. [NR-293077](https://new-relic.atlassian.net/browse/NR-293077)
+- [PR-380](https://github.com/newrelic/csec-java-agent/pull/380) Enabled sending of critical messages upon detection of server ports and confirmation of endpoints.
+  [NR-368586](https://new-relic.atlassian.net/browse/NR-368586), [NR-368585](https://new-relic.atlassian.net/browse/NR-368585)
+- [PR-385](https://github.com/newrelic/csec-java-agent/pull/385) Implemented support for skipping analysis of transitive APIs in IAST maintaining the integrity of the skip list is maintained. [NR-341300](https://new-relic.atlassian.net/browse/NR-341300)
+### Fixes
+- [PR-374](https://github.com/newrelic/csec-java-agent/pull/374) Resolved an issue that prevented event generation when the RXSS category was disabled.
+- [PR-384](https://github.com/newrelic/csec-java-agent/pull/384) Limited instrumentation capabilities in Apache Struts 2 following the release of version 7.0.0 on December 11, 2024. [NR-353483](https://new-relic.atlassian.net/browse/NR-353483)
+- [PR-384](https://github.com/newrelic/csec-java-agent/pull/384) Limited instrumentation capabilities in Apache Solr following the release of version 9.8.0 on January 21, 2025. [NR-370635](https://new-relic.atlassian.net/browse/NR-370635)
+- [PR-364](https://github.com/newrelic/csec-java-agent/pull/364) Modified HealthCheck to include the iastTestIdentifier and adjusted WebSocket headers to send instance-count only when its value is greater than zero. [NR-347851](https://new-relic.atlassian.net/browse/NR-347851)
+- [PR-349](https://github.com/newrelic/csec-java-agent/pull/349) Enhanced the process for rolling over log files, allowing for specific prefixes and suffixes. [NR-337016](https://new-relic.atlassian.net/browse/NR-337016)
+
 ## [1.6.0] - 2024-12-16
 ### Adds
 - [PR-329](https://github.com/newrelic/csec-java-agent/pull/329) Apache Pekko Server Support: The security agent now supports Apache Pekko Server version 1.0.0 and newer, compatible with Scala 2.13 and above. [NR-308780](https://new-relic.atlassian.net/browse/NR-308780), [NR-308781](https://new-relic.atlassian.net/browse/NR-308781), [NR-308791](https://new-relic.atlassian.net/browse/NR-308791), [NR-308792](https://new-relic.atlassian.net/browse/NR-308792) [NR-308782](https://new-relic.atlassian.net/browse/NR-308782)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # The agent version.
-agentVersion=1.6.0
+agentVersion=1.6.1
 jsonVersion=1.2.9
 # Updated exposed NR APM API version.
 nrAPIVersion=8.12.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # The agent version.
 agentVersion=1.6.1
-jsonVersion=1.2.9
+jsonVersion=1.2.10
 # Updated exposed NR APM API version.
 nrAPIVersion=8.12.0
 

--- a/instrumentation-security/servlet-2.4/src/main/java/javax/servlet/FilterChain_Instrumentation.java
+++ b/instrumentation-security/servlet-2.4/src/main/java/javax/servlet/FilterChain_Instrumentation.java
@@ -96,9 +96,10 @@ public abstract class FilterChain_Instrumentation {
             if (!NewRelicSecurity.isHookProcessingActive() || NewRelicSecurity.getAgent().getIastDetectionCategory().getRxssEnabled() || Boolean.TRUE.equals(NewRelicSecurity.getAgent().getSecurityMetaData().getCustomAttribute("RXSS_PROCESSED", Boolean.class))) {
                 return;
             }
-            if(NewRelic.getAgent().getTransaction().isWebTransaction()) {
+            if(NewRelic.getAgent().getTransaction().isWebTransaction() && response != null) {
                 HttpServletResponse httpServletResponse = (HttpServletResponse) response;
                 NewRelicSecurity.getAgent().getSecurityMetaData().getResponse().setResponseCode(httpServletResponse.getStatus());
+                NewRelicSecurity.getAgent().getSecurityMetaData().getResponse().setResponseContentType(httpServletResponse.getContentType());
             }
             ServletHelper.executeBeforeExitingTransaction();
             //Add request URI hash to low severity event filter

--- a/instrumentation-security/servlet-2.4/src/main/java/javax/servlet/Filter_Instrumentation.java
+++ b/instrumentation-security/servlet-2.4/src/main/java/javax/servlet/Filter_Instrumentation.java
@@ -89,9 +89,10 @@ public abstract class Filter_Instrumentation {
             ) {
                 return;
             }
-            if(NewRelic.getAgent().getTransaction().isWebTransaction()) {
+            if(NewRelic.getAgent().getTransaction().isWebTransaction() && response != null) {
                 HttpServletResponse httpServletResponse = (HttpServletResponse) response;
                 NewRelicSecurity.getAgent().getSecurityMetaData().getResponse().setResponseCode(httpServletResponse.getStatus());
+                NewRelicSecurity.getAgent().getSecurityMetaData().getResponse().setResponseContentType(httpServletResponse.getContentType());
             }
             ServletHelper.executeBeforeExitingTransaction();
             //Add request URI hash to low severity event filter

--- a/instrumentation-security/servlet-5.0/src/main/java/jakarta/servlet/FilterChain_Instrumentation.java
+++ b/instrumentation-security/servlet-5.0/src/main/java/jakarta/servlet/FilterChain_Instrumentation.java
@@ -89,9 +89,10 @@ public abstract class FilterChain_Instrumentation {
             if (!NewRelicSecurity.isHookProcessingActive() || NewRelicSecurity.getAgent().getIastDetectionCategory().getRxssEnabled() || Boolean.TRUE.equals(NewRelicSecurity.getAgent().getSecurityMetaData().getCustomAttribute("RXSS_PROCESSED", Boolean.class))) {
                 return;
             }
-            if(NewRelic.getAgent().getTransaction().isWebTransaction()) {
+            if(NewRelic.getAgent().getTransaction().isWebTransaction() && response != null) {
                 HttpServletResponse httpServletResponse = (HttpServletResponse) response;
                 NewRelicSecurity.getAgent().getSecurityMetaData().getResponse().setResponseCode(httpServletResponse.getStatus());
+                NewRelicSecurity.getAgent().getSecurityMetaData().getResponse().setResponseContentType(httpServletResponse.getContentType());
             }
             ServletHelper.executeBeforeExitingTransaction();
             //Add request URI hash to low severity event filter

--- a/instrumentation-security/servlet-5.0/src/main/java/jakarta/servlet/Filter_Instrumentation.java
+++ b/instrumentation-security/servlet-5.0/src/main/java/jakarta/servlet/Filter_Instrumentation.java
@@ -91,9 +91,10 @@ public abstract class Filter_Instrumentation {
             if (!NewRelicSecurity.isHookProcessingActive() || NewRelicSecurity.getAgent().getIastDetectionCategory().getRxssEnabled() || Boolean.TRUE.equals(NewRelicSecurity.getAgent().getSecurityMetaData().getCustomAttribute("RXSS_PROCESSED", Boolean.class))) {
                 return;
             }
-            if(NewRelic.getAgent().getTransaction().isWebTransaction()) {
+            if(NewRelic.getAgent().getTransaction().isWebTransaction() && response != null) {
                 HttpServletResponse httpServletResponse = (HttpServletResponse) response;
                 NewRelicSecurity.getAgent().getSecurityMetaData().getResponse().setResponseCode(httpServletResponse.getStatus());
+                NewRelicSecurity.getAgent().getSecurityMetaData().getResponse().setResponseContentType(httpServletResponse.getContentType());
             }
             ServletHelper.executeBeforeExitingTransaction();
 

--- a/instrumentation-security/servlet-6.0/src/main/java/jakarta/servlet/FilterChain_Instrumentation.java
+++ b/instrumentation-security/servlet-6.0/src/main/java/jakarta/servlet/FilterChain_Instrumentation.java
@@ -91,9 +91,10 @@ public abstract class FilterChain_Instrumentation {
             ) {
                 return;
             }
-            if(NewRelic.getAgent().getTransaction().isWebTransaction()) {
+            if(NewRelic.getAgent().getTransaction().isWebTransaction() && response != null) {
                 HttpServletResponse httpServletResponse = (HttpServletResponse) response;
                 NewRelicSecurity.getAgent().getSecurityMetaData().getResponse().setResponseCode(httpServletResponse.getStatus());
+                NewRelicSecurity.getAgent().getSecurityMetaData().getResponse().setResponseContentType(httpServletResponse.getContentType());
             }
             ServletHelper.executeBeforeExitingTransaction();
             //Add request URI hash to low severity event filter

--- a/instrumentation-security/servlet-6.0/src/main/java/jakarta/servlet/Filter_Instrumentation.java
+++ b/instrumentation-security/servlet-6.0/src/main/java/jakarta/servlet/Filter_Instrumentation.java
@@ -93,9 +93,10 @@ public abstract class Filter_Instrumentation {
             ) {
                 return;
             }
-            if(NewRelic.getAgent().getTransaction().isWebTransaction()) {
+            if(NewRelic.getAgent().getTransaction().isWebTransaction() && response != null) {
                 HttpServletResponse httpServletResponse = (HttpServletResponse) response;
                 NewRelicSecurity.getAgent().getSecurityMetaData().getResponse().setResponseCode(httpServletResponse.getStatus());
+                NewRelicSecurity.getAgent().getSecurityMetaData().getResponse().setResponseContentType(httpServletResponse.getContentType());
             }
             ServletHelper.executeBeforeExitingTransaction();
             //Add request URI hash to low severity event filter

--- a/newrelic-security-agent/src/main/java/com/newrelic/agent/security/instrumentator/dispatcher/Dispatcher.java
+++ b/newrelic-security-agent/src/main/java/com/newrelic/agent/security/instrumentator/dispatcher/Dispatcher.java
@@ -9,6 +9,8 @@ import com.newrelic.agent.security.instrumentator.utils.CallbackUtils;
 import com.newrelic.agent.security.instrumentator.utils.INRSettingsKey;
 import com.newrelic.agent.security.intcodeagent.apache.httpclient.IastHttpClient;
 import com.newrelic.agent.security.intcodeagent.filelogging.FileLoggerThreadPool;
+import com.newrelic.agent.security.intcodeagent.utils.IastExclusionUtils;
+import com.newrelic.agent.security.intcodeagent.utils.RestrictionUtility;
 import com.newrelic.api.agent.security.Agent;
 import com.newrelic.api.agent.security.NewRelicSecurity;
 import com.newrelic.api.agent.security.utils.logging.LogLevel;
@@ -185,6 +187,9 @@ public class Dispatcher implements Callable {
                     break;
                 case HTTP_REQUEST:
                     SSRFOperation ssrfOperationalBean = (SSRFOperation) operation;
+                    if(RestrictionUtility.skippedApiDetected(AgentConfig.getInstance().getAgentMode().getSkipScan(), ((SSRFOperation) operation).getArg())) {
+                        IastExclusionUtils.getInstance().registerSkippedTrace(NewRelic.getAgent().getTraceMetadata().getTraceId());
+                    }
                     eventBean = prepareSSRFEvent(eventBean, ssrfOperationalBean);
                     break;
                 case XPATH:

--- a/newrelic-security-agent/src/main/java/com/newrelic/agent/security/instrumentator/dispatcher/DispatcherPool.java
+++ b/newrelic-security-agent/src/main/java/com/newrelic/agent/security/instrumentator/dispatcher/DispatcherPool.java
@@ -5,6 +5,7 @@ import com.newrelic.agent.security.instrumentator.httpclient.RestRequestThreadPo
 import com.newrelic.agent.security.intcodeagent.executor.CustomFutureTask;
 import com.newrelic.agent.security.intcodeagent.executor.CustomThreadPoolExecutor;
 import com.newrelic.agent.security.intcodeagent.filelogging.FileLoggerThreadPool;
+import com.newrelic.agent.security.intcodeagent.utils.IastExclusionUtils;
 import com.newrelic.api.agent.security.utils.logging.LogLevel;
 import com.newrelic.agent.security.intcodeagent.logging.IAgentConstants;
 import com.newrelic.agent.security.intcodeagent.models.javaagent.EventStats;
@@ -217,6 +218,9 @@ public class DispatcherPool {
         TraceMetadata traceMetadata = NewRelic.getAgent().getTraceMetadata();
         securityMetaData.addCustomAttribute(NR_APM_TRACE_ID, traceMetadata.getTraceId());
         securityMetaData.addCustomAttribute(NR_APM_SPAN_ID, traceMetadata.getSpanId());
+
+        IastExclusionUtils.getInstance().addEncounteredTrace(traceMetadata.getTraceId(), operation.getApiID());
+
         this.executor.submit(new Dispatcher(operation, new SecurityMetaData(securityMetaData)));
         AgentInfo.getInstance().getJaHealthCheck().getEventStats().getDispatcher().incrementSubmitted();
 

--- a/newrelic-security-agent/src/main/java/com/newrelic/agent/security/instrumentator/httpclient/RestRequestProcessor.java
+++ b/newrelic-security-agent/src/main/java/com/newrelic/agent/security/instrumentator/httpclient/RestRequestProcessor.java
@@ -8,6 +8,7 @@ import com.newrelic.agent.security.instrumentator.utils.CallbackUtils;
 import com.newrelic.agent.security.intcodeagent.apache.httpclient.IastHttpClient;
 import com.newrelic.agent.security.intcodeagent.filelogging.FileLoggerThreadPool;
 import com.newrelic.agent.security.intcodeagent.logging.IAgentConstants;
+import com.newrelic.agent.security.intcodeagent.utils.IastExclusionUtils;
 import com.newrelic.api.agent.security.NewRelicSecurity;
 import com.newrelic.api.agent.security.schema.ServerConnectionConfiguration;
 import com.newrelic.api.agent.security.utils.logging.LogLevel;
@@ -41,7 +42,8 @@ public class RestRequestProcessor implements Callable<Boolean> {
 
     public static final String JSON_PARSING_ERROR_WHILE_PROCESSING_FUZZING_REQUEST_S = "JSON parsing error while processing fuzzing request : %s";
     private static final int MAX_REPETITION = 3;
-    private static final String IAST_REQUEST_HAS_NO_ARGUMENTS = "IAST request has no arguments : %s";
+    public static final String ENDPOINT_LOCALHOST_S = "%s://localhost:%s";
+    private static final String IAST_REQUEST_HAS_NO_ARGUMENTS = "IAST request has incomplete arguments : %s";
     public static final String AGENT_IS_NOT_ACTIVE = "Agent is not active";
     public static final String WS_RECONNECTING = "Websocket reconnecting failing for control command id: %s";
     private IntCodeControlCommand controlCommand;
@@ -70,6 +72,12 @@ public class RestRequestProcessor implements Callable<Boolean> {
         if( !AgentInfo.getInstance().isAgentActive()) {
             logger.log(LogLevel.FINER, AGENT_IS_NOT_ACTIVE, RestRequestProcessor.class.getSimpleName());
             return false;
+        }
+
+        //Skip if API ID is registered under skip list
+        if(IastExclusionUtils.getInstance().skipTraceApi(controlCommand.getApiId())) {
+            logger.log(LogLevel.FINER, String.format("Skip the control command %s, the record already exist under Skip list.", controlCommand.getId()), RestRequestProcessor.class.getSimpleName());
+            return true;
         }
 
         FuzzRequestBean httpRequest = null;

--- a/newrelic-security-agent/src/main/java/com/newrelic/agent/security/intcodeagent/controlcommand/ControlCommandProcessor.java
+++ b/newrelic-security-agent/src/main/java/com/newrelic/agent/security/intcodeagent/controlcommand/ControlCommandProcessor.java
@@ -1,6 +1,7 @@
 package com.newrelic.agent.security.intcodeagent.controlcommand;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.newrelic.agent.security.AgentInfo;
 import com.newrelic.agent.security.instrumentator.httpclient.IASTDataTransferRequestProcessor;
 import com.newrelic.agent.security.instrumentator.httpclient.RestRequestProcessor;
@@ -66,6 +67,7 @@ public class ControlCommandProcessor implements Runnable {
     public static final String RECEIVED_IAST_COOLDOWN_WAITING_TILL_S = "Received IAST cooldown. Waiting for next : %s Seconds";
     public static final String PURGING_CONFIRMED_IAST_PROCESSED_RECORDS_COUNT_S = "Purging confirmed IAST processed records count : %s";
     public static final String PURGING_CONFIRMED_IAST_PROCESSED_RECORDS_S = "Purging confirmed IAST processed records : %s";
+    public static final String API_ID = "apiId";
 
 
     private String controlCommandMessage;
@@ -97,6 +99,9 @@ public class ControlCommandProcessor implements Runnable {
             controlCommand.setData(object.get(DATA));
             controlCommand.setControlCommand(Integer.valueOf(object.get(CONTROL_COMMAND).toString()));
             controlCommand.setReflectedMetaData((Map<String, String>) object.get(REFLECTED_METADATA));
+            if(object.get(API_ID) != null) {
+                controlCommand.setApiId(object.get(API_ID).toString());
+            }
 
         } catch (Throwable e) {
             logger.log(LogLevel.SEVERE, ERROR_IN_CONTROL_COMMAND_PROCESSOR, e,

--- a/newrelic-security-agent/src/main/java/com/newrelic/agent/security/intcodeagent/models/javaagent/IntCodeControlCommand.java
+++ b/newrelic-security-agent/src/main/java/com/newrelic/agent/security/intcodeagent/models/javaagent/IntCodeControlCommand.java
@@ -32,6 +32,7 @@ public class IntCodeControlCommand {
     private Object data;
     private List<String> arguments;
     private Map<String, String> reflectedMetaData;
+    private String apiId;
 
     public IntCodeControlCommand() {
     }
@@ -96,6 +97,14 @@ public class IntCodeControlCommand {
 
     public Map<String, String> getReflectedMetaData() {
         return reflectedMetaData;
+    }
+
+    public String getApiId() {
+        return apiId;
+    }
+
+    public void setApiId(String apiId) {
+        this.apiId = apiId;
     }
 
     public void setReflectedMetaData(Map<String, String> reflectedMetaData) {

--- a/newrelic-security-agent/src/main/java/com/newrelic/agent/security/intcodeagent/schedulers/SchedulerHelper.java
+++ b/newrelic-security-agent/src/main/java/com/newrelic/agent/security/intcodeagent/schedulers/SchedulerHelper.java
@@ -84,6 +84,26 @@ public class SchedulerHelper {
         return future;
     }
 
+    public ScheduledFuture<?> scheduleTTLMapCleanup(Runnable command,
+                                                               long initialDelay,
+                                                               long period,
+                                                               TimeUnit unit,
+                                                                String mapId){
+        if(scheduledFutureMap.containsKey("ttl-map-cleanup-"+mapId)){
+            throw new IllegalArgumentException("TTL map cleanup already scheduled for mapId: "+mapId);
+        }
+        ScheduledFuture<?> future = commonExecutor.scheduleWithFixedDelay(command, initialDelay, period, unit);
+        scheduledFutureMap.put("ttl-map-cleanup-"+mapId, future);
+        return future;
+    }
+
+    public void cancelTTLMapCleanup(String mapId){
+        if(scheduledFutureMap.containsKey("ttl-map-cleanup-"+mapId)){
+            ScheduledFuture<?> currentFuture = scheduledFutureMap.get("ttl-map-cleanup-"+mapId);
+            currentFuture.cancel(false);
+        }
+    }
+
     public ScheduledFuture<?> scheduleDailyLogRollover(Runnable command) {
 
         if(LogFileHelper.isDailyRollover()) {

--- a/newrelic-security-agent/src/main/java/com/newrelic/agent/security/intcodeagent/utils/IastExclusionUtils.java
+++ b/newrelic-security-agent/src/main/java/com/newrelic/agent/security/intcodeagent/utils/IastExclusionUtils.java
@@ -1,0 +1,69 @@
+package com.newrelic.agent.security.intcodeagent.utils;
+
+import com.newrelic.agent.security.intcodeagent.filelogging.FileLoggerThreadPool;
+import com.newrelic.api.agent.security.utils.logging.LogLevel;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class IastExclusionUtils {
+
+    private static final FileLoggerThreadPool logger = FileLoggerThreadPool.getInstance();
+
+    private final TTLMap<String, Set<String>> encounteredTraces = new TTLMap<>("encounteredTraces");
+
+    private final TTLMap<String, Boolean> skippedTraces = new TTLMap<>("skippedTraces");
+
+    private final Set<String> skippedTraceApis = ConcurrentHashMap.newKeySet();
+
+    private IastExclusionUtils() {
+    }
+
+    public boolean skippedTrace(String traceId) {
+        return skippedTraces.containsKey(traceId);
+    }
+
+    public boolean skipTraceApi(String id) {
+        return skippedTraceApis.contains(id);
+    }
+
+    private static final class InstanceHolder {
+        static final IastExclusionUtils instance = new IastExclusionUtils();
+    }
+
+    public static IastExclusionUtils getInstance() {
+        return InstanceHolder.instance;
+    }
+
+    public void addEncounteredTrace(String traceId, String operationApiId) {
+        Set<String> operationApiIds = encounteredTraces.get(traceId);
+        if (operationApiIds == null) {
+            operationApiIds = ConcurrentHashMap.newKeySet();
+            encounteredTraces.put(traceId, operationApiIds);
+        }
+        operationApiIds.add(operationApiId);
+        updateSkippedTraceApis(traceId, operationApiId);
+    }
+
+    public void registerSkippedTrace(String traceId) {
+        skippedTraces.put(traceId, true);
+        updateSkippedTraceApis(traceId);
+    }
+
+    private void updateSkippedTraceApis(String traceId) {
+        Set<String> operationApiIds = encounteredTraces.get(traceId);
+        if (operationApiIds != null) {
+            skippedTraceApis.addAll(operationApiIds);
+            logger.log(LogLevel.FINER, String.format("Adding trace to skip list: %s with following api ids: %s", skippedTraceApis, operationApiIds), IastExclusionUtils.class.getName());
+        }
+    }
+
+    private void updateSkippedTraceApis(String traceId, String operationApiId) {
+        if (skippedTraces.containsKey(traceId)) {
+            skippedTraceApis.add(operationApiId);
+            logger.log(LogLevel.FINER, "Adding api id to skip list: " + skippedTraceApis, IastExclusionUtils.class.getName());
+        }
+    }
+
+
+}

--- a/newrelic-security-agent/src/main/java/com/newrelic/agent/security/intcodeagent/utils/RestrictionUtility.java
+++ b/newrelic-security-agent/src/main/java/com/newrelic/agent/security/intcodeagent/utils/RestrictionUtility.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.newrelic.agent.security.intcodeagent.exceptions.RestrictionModeException;
 import com.newrelic.agent.security.intcodeagent.filelogging.FileLoggerThreadPool;
+import com.newrelic.api.agent.NewRelic;
 import com.newrelic.api.agent.security.instrumentation.helpers.ServletHelper;
 import com.newrelic.api.agent.security.schema.HttpRequest;
 import com.newrelic.api.agent.security.schema.policy.RestrictionCriteria;
@@ -41,19 +42,29 @@ public class RestrictionUtility {
     private static final FileLoggerThreadPool logger = FileLoggerThreadPool.getInstance();
 
     public static boolean skippedApiDetected(SkipScan skipScan, HttpRequest httpRequest) {
-        if (skipScan == null) {
-            return false;
-        }
+
         if (httpRequest == null) {
             return false;
         }
 
-        if(skipScan.getApiRoutes().isEmpty()) {
+        return skippedApiDetected(skipScan, httpRequest.getUrl());
+    }
+
+    public static boolean skippedApiDetected(SkipScan skipScan, String url) {
+
+        String uri = StringUtils.substringBefore(url, SEPARATOR_CHARS_QUESTION_MARK);
+
+        if (skipScan == null || skipScan.getApiRoutes().isEmpty()) {
             return false;
         }
 
+        if(IastExclusionUtils.getInstance().skippedTrace(NewRelic.getAgent().getTraceMetadata().getTraceId())) {
+            logger.log(LogLevel.FINER, String.format("Skipping the scan for url %s due to traceId %s", uri, NewRelic.getAgent().getTraceMetadata().getTraceId()), RestrictionUtility.class.getName());
+            return true;
+        }
+
         for (Pattern pattern : skipScan.getApiRoutes()) {
-            if (pattern.matcher(httpRequest.getUrl()).matches()) {
+            if (pattern.matcher(uri).matches()) {
                 return true;
             }
         }

--- a/newrelic-security-agent/src/main/java/com/newrelic/agent/security/intcodeagent/utils/TTLMap.java
+++ b/newrelic-security-agent/src/main/java/com/newrelic/agent/security/intcodeagent/utils/TTLMap.java
@@ -1,0 +1,56 @@
+package com.newrelic.agent.security.intcodeagent.utils;
+
+import com.newrelic.agent.security.intcodeagent.schedulers.SchedulerHelper;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+public class TTLMap<K, V> {
+
+        private final ConcurrentHashMap<K, V> map = new ConcurrentHashMap<>();
+        private final ConcurrentHashMap<K, Long> timestamps = new ConcurrentHashMap<>();
+        private final long TTL;
+        private final String id;
+
+        public TTLMap(String id) {
+            this(id, 300_000);// 5 minutes in milliseconds
+        }
+
+        public TTLMap(String id, long ttl) {
+            this.id = id;
+            TTL = ttl;
+            SchedulerHelper.getInstance().scheduleTTLMapCleanup(this::removeExpiredEntries, ttl, ttl, TimeUnit.MILLISECONDS, id);
+        }
+
+        public void put(K key, V value) {
+            map.put(key, value);
+            timestamps.put(key, System.currentTimeMillis());
+        }
+
+        public V get(K key) {
+            return map.get(key);
+        }
+
+        public void remove(K key) {
+            map.remove(key);
+            timestamps.remove(key);
+        }
+
+        private void removeExpiredEntries() {
+            long now = System.currentTimeMillis();
+            for (K key : timestamps.keySet()) {
+                if (now - timestamps.get(key) >= TTL) {
+                    map.remove(key);
+                    timestamps.remove(key);
+                }
+            }
+        }
+
+        public void shutdown() {
+            SchedulerHelper.getInstance().cancelTTLMapCleanup(this.id);
+        }
+
+        public boolean containsKey(K traceId) {
+            return map.containsKey(traceId);
+        }
+}

--- a/newrelic-security-agent/src/main/java/com/newrelic/agent/security/intcodeagent/websocket/WSClient.java
+++ b/newrelic-security-agent/src/main/java/com/newrelic/agent/security/intcodeagent/websocket/WSClient.java
@@ -400,4 +400,8 @@ public class WSClient extends WebSocketClient {
         }
     }
 
+    public static void setFirstServerConnectionSent(boolean firstServerConnectionSent1) {
+        firstServerConnectionSent.set(firstServerConnectionSent1);
+    }
+
 }

--- a/newrelic-security-agent/src/main/java/com/newrelic/agent/security/intcodeagent/websocket/WSClient.java
+++ b/newrelic-security-agent/src/main/java/com/newrelic/agent/security/intcodeagent/websocket/WSClient.java
@@ -263,7 +263,7 @@ public class WSClient extends WebSocketClient {
         logger.logInit(LogLevel.INFO, String.format(IAgentConstants.SENDING_APPLICATION_INFO_ON_WS_CONNECT, AgentInfo.getInstance().getApplicationInfo()), WSClient.class.getName());
         cleanIASTState();
         super.send(JsonConverter.toJSON(AgentInfo.getInstance().getApplicationInfo()));
-        if (!firstServerConnectionSent.get()) {
+        if (!firstServerConnectionSent.get() && !NewRelicSecurity.getAgent().getApplicationConnectionConfig().isEmpty()) {
             logger.postLogMessageIfNecessary(LogLevel.INFO, String.format("Unconfirmed connection configuration for this application is %s", NewRelicSecurity.getAgent().getApplicationConnectionConfig()), null, this.getClass().getName());
             firstServerConnectionSent.set(true);
         }

--- a/newrelic-security-agent/src/main/java/com/newrelic/api/agent/security/Agent.java
+++ b/newrelic-security-agent/src/main/java/com/newrelic/api/agent/security/Agent.java
@@ -1066,10 +1066,9 @@ public class Agent implements SecurityAgent {
     public boolean recordExceptions(SecurityMetaData securityMetaData, Throwable exception) {
         int responseCode = securityMetaData.getResponse().getResponseCode();
         String route = securityMetaData.getRequest().getUrl();
-        //TODO turn on after api endpoint route detection is merged.
-//        if(StringUtils.isNotBlank(securityMetaData.getRequest().getRoute())){
-//            route = securityMetaData.getRequest().getRoute();
-//        }
+        if(StringUtils.isNotBlank(securityMetaData.getRequest().getRoute())){
+            route = securityMetaData.getRequest().getRoute();
+        }
         LogMessageException messageException = null;
         if (exception != null) {
             messageException = new LogMessageException(exception, 0, 1, 20);

--- a/newrelic-security-agent/src/main/java/com/newrelic/api/agent/security/Agent.java
+++ b/newrelic-security-agent/src/main/java/com/newrelic/api/agent/security/Agent.java
@@ -376,6 +376,7 @@ public class Agent implements SecurityAgent {
 
                 SecurityMetaData securityMetaData = NewRelicSecurity.getAgent().getSecurityMetaData();
                 if(RestrictionUtility.skippedApiDetected(AgentConfig.getInstance().getAgentMode().getSkipScan(), securityMetaData.getRequest())){
+                    IastExclusionUtils.getInstance().registerSkippedTrace(NewRelic.getAgent().getTraceMetadata().getTraceId());
                     logger.log(LogLevel.FINER, String.format(SKIPPING_THE_API_S_AS_IT_IS_PART_OF_THE_SKIP_SCAN_LIST, securityMetaData.getRequest().getUrl()), Agent.class.getName());
                     return;
                 }

--- a/newrelic-security-agent/src/main/java/com/newrelic/api/agent/security/Agent.java
+++ b/newrelic-security-agent/src/main/java/com/newrelic/api/agent/security/Agent.java
@@ -896,6 +896,7 @@ public class Agent implements SecurityAgent {
         }
         if (logger != null && WSUtils.isConnected()) {
             logger.postLogMessageIfNecessary(LogLevel.INFO, String.format("Unconfirmed connection configuration for port %d and scheme %s added.", port, scheme), null, this.getClass().getName());
+            WSClient.setFirstServerConnectionSent(true);
         }
     }
 


### PR DESCRIPTION
### Adds
- [PR-309](https://github.com/newrelic/csec-java-agent/pull/309) Introduced API Endpoint detection for Resin Server. [NR-293077](https://new-relic.atlassian.net/browse/NR-293077)
- [PR-380](https://github.com/newrelic/csec-java-agent/pull/380) Enabled sending of critical messages upon detection of server ports and confirmation of endpoints.
  [NR-368586](https://new-relic.atlassian.net/browse/NR-368586), [NR-368585](https://new-relic.atlassian.net/browse/NR-368585)
- [PR-385](https://github.com/newrelic/csec-java-agent/pull/385) Implemented support for skipping analysis of transitive APIs in IAST maintaining the integrity of the skip list is maintained. [NR-341300](https://new-relic.atlassian.net/browse/NR-341300)
### Fixes
- [PR-374](https://github.com/newrelic/csec-java-agent/pull/374) Resolved an issue that prevented event generation when the RXSS category was disabled.
- [PR-384](https://github.com/newrelic/csec-java-agent/pull/384) Limited instrumentation capabilities in Apache Struts 2 following the release of version 7.0.0 on December 11, 2024. [NR-353483](https://new-relic.atlassian.net/browse/NR-353483)
- [PR-384](https://github.com/newrelic/csec-java-agent/pull/384) Limited instrumentation capabilities in Apache Solr following the release of version 9.8.0 on January 21, 2025. [NR-370635](https://new-relic.atlassian.net/browse/NR-370635)
- [PR-364](https://github.com/newrelic/csec-java-agent/pull/364) Modified HealthCheck to include the iastTestIdentifier and adjusted WebSocket headers to send instance-count only when its value is greater than zero. [NR-347851](https://new-relic.atlassian.net/browse/NR-347851)
- [PR-349](https://github.com/newrelic/csec-java-agent/pull/349) Enhanced the process for rolling over log files, allowing for specific prefixes and suffixes. [NR-337016](https://new-relic.atlassian.net/browse/NR-337016)


[NR-293077]: https://new-relic.atlassian.net/browse/NR-293077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NR-368586]: https://new-relic.atlassian.net/browse/NR-368586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NR-368585]: https://new-relic.atlassian.net/browse/NR-368585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NR-341300]: https://new-relic.atlassian.net/browse/NR-341300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NR-353483]: https://new-relic.atlassian.net/browse/NR-353483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ