### PR TITLE
NR-401021 : Limiting GraphQL Support version range

### DIFF
--- a/instrumentation-security/graphql-java-16.2/build.gradle
+++ b/instrumentation-security/graphql-java-16.2/build.gradle
@@ -10,7 +10,7 @@ jar {
 }
 
 verifyInstrumentation {
-    passesOnly('com.graphql-java:graphql-java:[16.0,)')
+    passesOnly('com.graphql-java:graphql-java:[16.0,23.0)')
     excludeRegex('com.graphql-java:graphql-java:(0.0.0|201|202).*')
     excludeRegex('com.graphql-java:graphql-java:.*(vTEST|-beta|-alpha1|-nf-execution|-rc|-TEST).*')
     exclude('com.graphql-java:graphql-java:15.0')


### PR DESCRIPTION
Limiting the supported version range for graphql due to new version released on April 7th, 2025.