### PR TITLE
CSEC Java Agent Version 1.7.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR-403](https://github.com/newrelic/csec-java-agent/pull/403) GraphQL Supported Version Range: Restricted the supported version range for GraphQL due to the release of a new version on April 7th, 2025
 
 ### Fixes
-- [PR-372](https://github.com/newrelic/csec-java-agent/pull/372) **Repeat IAST Request Relay Commands**: Reconfigured logic to repeat IAST control commands until the endpoint is confirmed.
+- [PR-372](https://github.com/newrelic/csec-java-agent/pull/372) **Repeat IAST Request Replay Commands**: Reconfigured logic to repeat IAST control commands until the endpoint is confirmed.
 
 
 ## [1.6.1] - 2025-3-1

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@ Noteworthy changes to the agent are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.7.0] - TBD
+## [1.7.0] - 2025-4-25
 ### Adds
 - [PR-395](https://github.com/newrelic/csec-java-agent/pull/395) **Support for Deserialization Vulnerability Detection**: Implemented mechanisms to detect vulnerabilities arising from unsafe deserialization processes.
 - [PR-395](https://github.com/newrelic/csec-java-agent/pull/395) **Support for Vulnerability Detection of Remote Code Invocation via Reflection**: Enhanced capability to identify security risks associated with remote code execution through reflection.
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixes
 - [PR-372](https://github.com/newrelic/csec-java-agent/pull/372) **Repeat IAST Request Replay Commands**: Reconfigured logic to repeat IAST control commands until the endpoint is confirmed.
 
+### Note
+- The instrumentation for the module `com.newrelic.instrumentation.security.java-reflection` is disabled by default. This is due to its impact on CPU utilization, which can significantly increase when the module is active.
+- **Action Required**: To detect unsafe reflection vulnerabilities effectively, enable the `com.newrelic.instrumentation.security.java-reflection` module.
 
 ## [1.6.1] - 2025-3-1
 ### Adds

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # The agent version.
-agentVersion=1.6.1
+agentVersion=1.7.0
 jsonVersion=1.2.11
 # Updated exposed NR APM API version.
 nrAPIVersion=8.12.0

--- a/instrumentation-security/deserialisation/build.gradle
+++ b/instrumentation-security/deserialisation/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 
 
 jar {
-    manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.security.deserialisation', 'Enabled': 'false'  }
+    manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.security.deserialisation' }
 }
 
 verifyInstrumentation {

--- a/instrumentation-security/deserialisation/build.gradle
+++ b/instrumentation-security/deserialisation/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 
 
 jar {
-    manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.security.deserialisation' }
+    manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.security.deserialisation', 'Enabled': 'false'  }
 }
 
 verifyInstrumentation {

--- a/instrumentation-security/java-reflection/build.gradle
+++ b/instrumentation-security/java-reflection/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 
 
 jar {
-    manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.security.java-reflection' }
+    manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.security.java-reflection', 'Enabled': 'false'  }
 }
 
 verifyInstrumentation {

--- a/instrumentation-security/jersey-2.16/src/main/java/com/newrelic/agent/security/instrumentation/jersey2/ContainerResponse_Instrumentation.java
+++ b/instrumentation-security/jersey-2.16/src/main/java/com/newrelic/agent/security/instrumentation/jersey2/ContainerResponse_Instrumentation.java
@@ -44,7 +44,7 @@ public abstract class ContainerResponse_Instrumentation {
     public void close() {
         boolean isLockAcquired = false;
         try {
-            isLockAcquired = GenericHelper.acquireLockIfPossible(VulnerabilityCaseType.REFLECTED_XSS, SERVLET_GET_IS_OPERATION_LOCK);
+            isLockAcquired = GenericHelper.acquireLockIfPossible(SERVLET_GET_IS_OPERATION_LOCK);
             if(isLockAcquired && GenericHelper.isLockAcquired(HttpRequestHelper.getNrSecCustomAttribForPostProcessing())) {
                 HttpRequestHelper.postProcessSecurityHook(this.getClass().getName(), getWrappedMessageContext());
             }

--- a/instrumentation-security/jersey-2/src/main/java/com/newrelic/agent/security/instrumentation/jersey2/ContainerResponse_Instrumentation.java
+++ b/instrumentation-security/jersey-2/src/main/java/com/newrelic/agent/security/instrumentation/jersey2/ContainerResponse_Instrumentation.java
@@ -43,7 +43,7 @@ public abstract class ContainerResponse_Instrumentation {
     public void close() {
         boolean isLockAcquired = false;
         try {
-            isLockAcquired = GenericHelper.acquireLockIfPossible(VulnerabilityCaseType.REFLECTED_XSS, SERVLET_GET_IS_OPERATION_LOCK);
+            isLockAcquired = GenericHelper.acquireLockIfPossible(SERVLET_GET_IS_OPERATION_LOCK);
             if(isLockAcquired && GenericHelper.isLockAcquired(HttpRequestHelper.getNrSecCustomAttribForPostProcessing())) {
                 HttpRequestHelper.postProcessSecurityHook(this.getClass().getName(), getWrappedMessageContext());
             }

--- a/instrumentation-security/jersey-3/src/main/java/com/newrelic/agent/security/instrumentation/jersey2/ContainerResponse_Instrumentation.java
+++ b/instrumentation-security/jersey-3/src/main/java/com/newrelic/agent/security/instrumentation/jersey2/ContainerResponse_Instrumentation.java
@@ -43,7 +43,7 @@ public abstract class ContainerResponse_Instrumentation {
     public void close() {
         boolean isLockAcquired = false;
         try {
-            isLockAcquired = GenericHelper.acquireLockIfPossible(VulnerabilityCaseType.REFLECTED_XSS, SERVLET_GET_IS_OPERATION_LOCK);
+            isLockAcquired = GenericHelper.acquireLockIfPossible(SERVLET_GET_IS_OPERATION_LOCK);
             if(isLockAcquired && GenericHelper.isLockAcquired(HttpRequestHelper.getNrSecCustomAttribForPostProcessing())) {
                 HttpRequestHelper.postProcessSecurityHook(this.getClass().getName(), getWrappedMessageContext());
             }

--- a/instrumentation-security/mule-3.6/src/main/java/org/mule/module/http/internal/domain/response/HttpResponseBuilder_Instrumentation.java
+++ b/instrumentation-security/mule-3.6/src/main/java/org/mule/module/http/internal/domain/response/HttpResponseBuilder_Instrumentation.java
@@ -19,8 +19,8 @@ import org.mule.module.http.internal.domain.HttpEntity;
 @Weave(type = MatchType.ExactClass, originalName = "org.mule.module.http.internal.domain.response.HttpResponseBuilder")
 public class HttpResponseBuilder_Instrumentation {
 
-    private final ResponseStatus responseStatus = Weaver.callOriginal();
-    private final HttpEntity body = Weaver.callOriginal();
+    private ResponseStatus responseStatus = Weaver.callOriginal();
+    private HttpEntity body = Weaver.callOriginal();
 
     public HttpResponse build() {
         HttpResponse response = Weaver.callOriginal();

--- a/instrumentation-security/mule-3.7/src/main/java/org/mule/module/http/internal/domain/response/HttpResponseBuilder_Instrumentation.java
+++ b/instrumentation-security/mule-3.7/src/main/java/org/mule/module/http/internal/domain/response/HttpResponseBuilder_Instrumentation.java
@@ -19,8 +19,8 @@ import org.mule.module.http.internal.domain.HttpEntity;
 @Weave(type = MatchType.ExactClass, originalName = "org.mule.module.http.internal.domain.response.HttpResponseBuilder")
 public class HttpResponseBuilder_Instrumentation {
     
-    private final ResponseStatus responseStatus = Weaver.callOriginal();
-    private final HttpEntity body = Weaver.callOriginal();
+    private ResponseStatus responseStatus = Weaver.callOriginal();
+    private HttpEntity body = Weaver.callOriginal();
 
     public HttpResponse build() {
         HttpResponse response = Weaver.callOriginal();

--- a/instrumentation-security/servlet-2.4/src/test/java/com/nr/agent/security/instrumentation/servlet24/HttpSessionTest.java
+++ b/instrumentation-security/servlet-2.4/src/test/java/com/nr/agent/security/instrumentation/servlet24/HttpSessionTest.java
@@ -35,7 +35,6 @@ public class HttpSessionTest {
         SecurityIntrospector introspector = SecurityInstrumentationTestRunner.getIntrospector();
         List<AbstractOperation> operations = introspector.getOperations();
         Assert.assertTrue("No operations detected", operations.size() > 0);
-        Assert.assertTrue("Unexpected operation count detected", operations.size() == 2 || operations.size() == 3);
         TrustBoundaryOperation targetOperation = null;
         int i=0;
         for (AbstractOperation operation : operations) {
@@ -65,7 +64,6 @@ public class HttpSessionTest {
         SecurityIntrospector introspector = SecurityInstrumentationTestRunner.getIntrospector();
         List<AbstractOperation> operations = introspector.getOperations();
         Assert.assertFalse(operations.isEmpty());
-        Assert.assertTrue("Unexpected operation count detected", operations.size() == 2 || operations.size() == 3);
         TrustBoundaryOperation targetOperation = null;
         for (AbstractOperation operation : operations) {
             if (operation instanceof TrustBoundaryOperation)
@@ -86,7 +84,6 @@ public class HttpSessionTest {
         SecurityIntrospector introspector = SecurityInstrumentationTestRunner.getIntrospector();
         List<AbstractOperation> operations = introspector.getOperations();
         Assert.assertTrue("No operations detected", operations.size() > 0);
-        Assert.assertTrue("Unexpected operation count detected", operations.size() == 1 || operations.size() == 2);
         SecureCookieOperationSet targetOperation = null;
         targetOperation = verifySecureCookieOp(operations);
 

--- a/newrelic-security-agent/build.gradle
+++ b/newrelic-security-agent/build.gradle
@@ -203,6 +203,9 @@ tasks.register('generate-sbom') {
     def parsedJson = new JsonSlurper().parseText(req.getInputStream().getText())
 
     try {
+        if (!project.buildDir.exists()) {
+            mkdir project.buildDir;
+        }
         def reportsDir = Paths.get("$buildDir", "reports")
         def sbomFile = new File("$buildDir/reports", "SBOM.json")
         if (Files.exists(reportsDir) || Files.createDirectory(reportsDir)) {

--- a/newrelic-security-agent/src/main/java/com/newrelic/agent/security/AgentConfig.java
+++ b/newrelic-security-agent/src/main/java/com/newrelic/agent/security/AgentConfig.java
@@ -318,7 +318,7 @@ public class AgentConfig {
         if(value instanceof Boolean) {
             logLevel = IUtilConstants.OFF;
         } else {
-            logLevel = NewRelic.getAgent().getConfig().getValue(IUtilConstants.NR_LOG_LEVEL, LogLevel.FINEST.name());
+            logLevel = NewRelic.getAgent().getConfig().getValue(IUtilConstants.NR_LOG_LEVEL, IUtilConstants.INFO);
         }
 
         try {

--- a/newrelic-security-api-test-impl/src/main/java/com/newrelic/api/agent/security/Agent.java
+++ b/newrelic-security-api-test-impl/src/main/java/com/newrelic/api/agent/security/Agent.java
@@ -85,6 +85,8 @@ public class Agent implements SecurityAgent {
             return;
         }
         operation.setApiID(apiId);
+        String executionId = "dummy-exec-id";
+        operation.setExecutionId(executionId);
         operation.setStartTime(Instant.now().toEpochMilli());
         StackTraceElement[] trace = Thread.currentThread().getStackTrace();
         operation.setStackTrace(Arrays.copyOfRange(trace, 1, trace.length));

--- a/newrelic-security-api-test-impl/src/main/java/com/newrelic/api/agent/security/Agent.java
+++ b/newrelic-security-api-test-impl/src/main/java/com/newrelic/api/agent/security/Agent.java
@@ -8,6 +8,7 @@ import com.newrelic.api.agent.security.schema.SecurityMetaData;
 import com.newrelic.api.agent.security.schema.ServerConnectionConfiguration;
 import com.newrelic.api.agent.security.schema.operation.FileIntegrityOperation;
 import com.newrelic.api.agent.security.schema.operation.FileOperation;
+import com.newrelic.api.agent.security.schema.operation.SecureCookieOperationSet;
 import com.newrelic.api.agent.security.schema.policy.AgentPolicy;
 import com.newrelic.api.agent.security.schema.policy.IastDetectionCategory;
 import com.newrelic.api.agent.security.utils.logging.LogLevel;
@@ -95,6 +96,9 @@ public class Agent implements SecurityAgent {
 
     @Override
     public void registerExitEvent(AbstractOperation operation) {
+        if (operation instanceof SecureCookieOperationSet) {
+            this.getSecurityMetaData().getCustomAttribute(OPERATIONS, List.class).add(operation);
+        }
         this.getSecurityMetaData().getCustomAttribute(EXIT_OPERATIONS, List.class).add(operation);
     }
 


### PR DESCRIPTION
### Adds
- [PR-395](https://github.com/newrelic/csec-java-agent/pull/395) **Support for Deserialization Vulnerability Detection**: Implemented mechanisms to detect vulnerabilities arising from unsafe deserialization processes.
- [PR-395](https://github.com/newrelic/csec-java-agent/pull/395) **Support for Vulnerability Detection of Remote Code Invocation via Reflection**: Enhanced capability to identify security risks associated with remote code execution through reflection.
- [PR-343](https://github.com/newrelic/csec-java-agent/pull/343) **HTTP Response Handling for Vulnerabilities**: Developed the functionality to send HTTP responses for detected vulnerabilities directly to the UI.

### Changes
- [PR-343](https://github.com/newrelic/csec-java-agent/pull/343) **Trimmed Response Body**: Updated the response handling logic to trim response bodies to a maximum of 500KB when larger. This optimization aids in performance and resource conservation.
- [PR-396](https://github.com/newrelic/csec-java-agent/pull/396) Upgraded _commons-io:commons-io_ from version 2.7 to 2.14.0
- [PR-403](https://github.com/newrelic/csec-java-agent/pull/403) GraphQL Supported Version Range: Restricted the supported version range for GraphQL due to the release of a new version on April 7th, 2025

### Fixes
- [PR-372](https://github.com/newrelic/csec-java-agent/pull/372) **Repeat IAST Request Replay Commands**: Reconfigured logic to repeat IAST control commands until the endpoint is confirmed.

### Note
- The instrumentation for the module `com.newrelic.instrumentation.security.java-reflection` is disabled by default. This is due to its impact on CPU utilization, which can significantly increase when the module is active.
- **Action Required**: To detect unsafe reflection vulnerabilities effectively, enable the `com.newrelic.instrumentation.security.java-reflection` module.
