### PR TITLE
Remediate Jackson-databind CVEs and instrumentation-verifier failure

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -3,6 +3,8 @@ name: Dependency Submission
 on:
   push:
     branches: ['main']
+  pull_request:
+    branches: ['main']
 
 permissions:
   contents: write
@@ -23,5 +25,16 @@ jobs:
         with:
           dependency-graph-include-projects: ':newrelic-security-(agent|api)'
           build-scan-publish: true
-          build-scan-terms-of-use-url: "https://gralde.com/help/legal-terms-of-use"
+          build-scan-terms-of-use-url: "https://gradle.com/help/legal-terms-of-use"
           build-scan-terms-of-use-agree: "yes"
+
+  dependency-review:
+    needs: dependency-submission # Wait for graph submission to finish
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: 'low' # Fails the action if CVE is found
+          retry-on-snapshot-warnings: true
+          retry-on-snapshot-warnings-timeout: 300

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,13 @@ Noteworthy changes to the agent are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.0] - TBD
+### Changes
+- Upgraded _com.fasterxml.jackson.core:jackson-databind_ from version 2.14.2 to 2.18.9 to address [CVE-2026-54512](https://www.cve.org/CVERecord?id=CVE-2026-54512) and [CVE-2026-54513](https://www.cve.org/CVERecord?id=CVE-2026-54513).
+- Removed the defunct `jcenter()` repository from `buildSrc`, root, and `unittest-helper-agent` build files, replacing it with `mavenCentral()`/`gradlePluginPortal()` where needed, to unblock dependency resolution now that JCenter is shut down.
+- For JSP and Servlet excluded milestone (`-M`) and beta pre-release versions from verification.
+- Refined Lettuce instrumentation's to support the full `[5.0.0.RELEASE,)` version range.
+
 ## [1.7.0] - 2025-4-25
 ### Adds
 - [PR-395](https://github.com/newrelic/csec-java-agent/pull/395) **Support for Deserialization Vulnerability Detection**: Implemented mechanisms to detect vulnerabilities arising from unsafe deserialization processes.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -12,19 +12,19 @@ can be found at https://github.com/newrelic/.
 
 ### Dependencies 
 
-**1**. **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-databind` **Version:** `2.14.2` 
+**1**. **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-databind` **Version:** `2.18.8` 
 > - **Project URL**: [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
-> - **Embedded license files**: [jackson-databind-2.14.2.jar/META-INF/LICENSE](./third-party-dependencies/jackson-databind-2.14.2.jar/META-INF/LICENSE) 
-    - [jackson-databind-2.14.2.jar/META-INF/NOTICE](./third-party-dependencies/jackson-databind-2.14.2.jar/META-INF/NOTICE)
+> - **Embedded license files**: [jackson-databind-2.18.8.jar/META-INF/LICENSE](./third-party-dependencies/jackson-databind-2.18.8.jar/META-INF/LICENSE) 
+    - [jackson-databind-2.18.8.jar/META-INF/NOTICE](./third-party-dependencies/jackson-databind-2.18.8.jar/META-INF/NOTICE)
 
-**2**. **Group:** `com.fasterxml.jackson.dataformat` **Name:** `jackson-dataformat-properties` **Version:** `2.14.2` 
+**2**. **Group:** `com.fasterxml.jackson.dataformat` **Name:** `jackson-dataformat-properties` **Version:** `2.18.8` 
 > - **Project URL**: [https://github.com/FasterXML/jackson-dataformats-text](https://github.com/FasterXML/jackson-dataformats-text)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
-> - **Embedded license files**: [jackson-dataformat-properties-2.14.2.jar/META-INF/LICENSE](./third-party-dependencies/jackson-dataformat-properties-2.14.2.jar/META-INF/LICENSE) 
-    - [jackson-dataformat-properties-2.14.2.jar/META-INF/NOTICE](./third-party-dependencies/jackson-dataformat-properties-2.14.2.jar/META-INF/NOTICE)
+> - **Embedded license files**: [jackson-dataformat-properties-2.18.8.jar/META-INF/LICENSE](./third-party-dependencies/jackson-dataformat-properties-2.18.8.jar/META-INF/LICENSE) 
+    - [jackson-dataformat-properties-2.18.8.jar/META-INF/NOTICE](./third-party-dependencies/jackson-dataformat-properties-2.18.8.jar/META-INF/NOTICE)
 
 **3**. **Group:** `com.github.erosb` **Name:** `everit-json-schema` **Version:** `1.14.2` 
 > - **POM Project URL**: [https://github.com/erosb/everit-json-schema](https://github.com/erosb/everit-json-schema)
@@ -83,19 +83,19 @@ can be found at https://github.com/newrelic/.
 > - **POM License**: The Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [newrelic-api-8.3.0-SNAPSHOT.jar/LICENSE](./third-party-dependencies/newrelic-api-8.3.0-SNAPSHOT.jar/LICENSE)
 
-**14**. **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-databind` **Version:** `2.14.2` 
+**14**. **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-databind` **Version:** `2.18.8` 
 > - **Project URL**: [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
-> - **Embedded license files**: [jackson-databind-2.14.2.jar/META-INF/LICENSE](./third-party-dependencies/jackson-databind-2.14.2.jar/META-INF/LICENSE) 
-    - [jackson-databind-2.14.2.jar/META-INF/NOTICE](./third-party-dependencies/jackson-databind-2.14.2.jar/META-INF/NOTICE)
+> - **Embedded license files**: [jackson-databind-2.18.8.jar/META-INF/LICENSE](./third-party-dependencies/jackson-databind-2.18.8.jar/META-INF/LICENSE) 
+    - [jackson-databind-2.18.8.jar/META-INF/NOTICE](./third-party-dependencies/jackson-databind-2.18.8.jar/META-INF/NOTICE)
 
-**15**. **Group:** `com.fasterxml.jackson.dataformat` **Name:** `jackson-dataformat-properties` **Version:** `2.14.2` 
+**15**. **Group:** `com.fasterxml.jackson.dataformat` **Name:** `jackson-dataformat-properties` **Version:** `2.18.8` 
 > - **Project URL**: [https://github.com/FasterXML/jackson-dataformats-text](https://github.com/FasterXML/jackson-dataformats-text)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
-> - **Embedded license files**: [jackson-dataformat-properties-2.14.2.jar/META-INF/LICENSE](./third-party-dependencies/jackson-dataformat-properties-2.14.2.jar/META-INF/LICENSE) 
-    - [jackson-dataformat-properties-2.14.2.jar/META-INF/NOTICE](./third-party-dependencies/jackson-dataformat-properties-2.14.2.jar/META-INF/NOTICE)
+> - **Embedded license files**: [jackson-dataformat-properties-2.18.8.jar/META-INF/LICENSE](./third-party-dependencies/jackson-dataformat-properties-2.18.8.jar/META-INF/LICENSE) 
+    - [jackson-dataformat-properties-2.18.8.jar/META-INF/NOTICE](./third-party-dependencies/jackson-dataformat-properties-2.18.8.jar/META-INF/NOTICE)
 
 **16**. **Group:** `com.googlecode.json-simple` **Name:** `json-simple` **Version:** `1.1.1` 
 > - **POM Project URL**: [http://code.google.com/p/json-simple/](http://code.google.com/p/json-simple/)

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -12,101 +12,87 @@ can be found at https://github.com/newrelic/.
 
 ### Dependencies 
 
-**1**. **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-databind` **Version:** `2.18.8` 
+**1**. **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-databind` **Version:** `2.18.9` 
 > - **Project URL**: [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
-> - **Embedded license files**: [jackson-databind-2.18.8.jar/META-INF/LICENSE](./third-party-dependencies/jackson-databind-2.18.8.jar/META-INF/LICENSE) 
-    - [jackson-databind-2.18.8.jar/META-INF/NOTICE](./third-party-dependencies/jackson-databind-2.18.8.jar/META-INF/NOTICE)
+> - **Embedded license files**: [jackson-databind-2.18.9.jar/META-INF/LICENSE](./third-party-dependencies/jackson-databind-2.18.8.jar/META-INF/LICENSE) 
+    - [jackson-databind-2.18.9.jar/META-INF/NOTICE](./third-party-dependencies/jackson-databind-2.18.9.jar/META-INF/NOTICE)
 
-**2**. **Group:** `com.fasterxml.jackson.dataformat` **Name:** `jackson-dataformat-properties` **Version:** `2.18.8` 
-> - **Project URL**: [https://github.com/FasterXML/jackson-dataformats-text](https://github.com/FasterXML/jackson-dataformats-text)
-> - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-> - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
-> - **Embedded license files**: [jackson-dataformat-properties-2.18.8.jar/META-INF/LICENSE](./third-party-dependencies/jackson-dataformat-properties-2.18.8.jar/META-INF/LICENSE) 
-    - [jackson-dataformat-properties-2.18.8.jar/META-INF/NOTICE](./third-party-dependencies/jackson-dataformat-properties-2.18.8.jar/META-INF/NOTICE)
-
-**3**. **Group:** `com.github.erosb` **Name:** `everit-json-schema` **Version:** `1.14.2` 
+**2**. **Group:** `com.github.erosb` **Name:** `everit-json-schema` **Version:** `1.14.2` 
 > - **POM Project URL**: [https://github.com/erosb/everit-json-schema](https://github.com/erosb/everit-json-schema)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**4**. **Group:** `commons-codec` **Name:** `commons-codec` **Version:** `1.15` 
+**3**. **Group:** `commons-codec` **Name:** `commons-codec` **Version:** `1.15` 
 > - **Project URL**: [https://commons.apache.org/proper/commons-codec/](https://commons.apache.org/proper/commons-codec/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [commons-codec-1.15.jar/META-INF/LICENSE.txt](./third-party-dependencies/commons-codec-1.15.jar/META-INF/LICENSE.txt) 
     - [commons-codec-1.15.jar/META-INF/NOTICE.txt](./third-party-dependencies/commons-codec-1.15.jar/META-INF/NOTICE.txt)
 
-**5**. **Group:** `commons-io` **Name:** `commons-io` **Version:** `2.7` 
+**4**. **Group:** `commons-io` **Name:** `commons-io` **Version:** `2.7` 
 > - **Project URL**: [https://commons.apache.org/proper/commons-io/](https://commons.apache.org/proper/commons-io/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [commons-io-2.7.jar/META-INF/LICENSE.txt](./third-party-dependencies/commons-io-2.7.jar/META-INF/LICENSE.txt) 
     - [commons-io-2.7.jar/META-INF/NOTICE.txt](./third-party-dependencies/commons-io-2.7.jar/META-INF/NOTICE.txt)
 
-**6**. **Group:** `commons-net` **Name:** `commons-net` **Version:** `3.9.0` 
+**5**. **Group:** `commons-net` **Name:** `commons-net` **Version:** `3.9.0` 
 > - **Project URL**: [https://commons.apache.org/proper/commons-net/](https://commons.apache.org/proper/commons-net/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [commons-net-3.9.0.jar/META-INF/LICENSE.txt](./third-party-dependencies/commons-net-3.9.0.jar/META-INF/LICENSE.txt) 
     - [commons-net-3.9.0.jar/META-INF/NOTICE.txt](./third-party-dependencies/commons-net-3.9.0.jar/META-INF/NOTICE.txt)
 
-**7**. **Group:** `net.openhft` **Name:** `zero-allocation-hashing` **Version:** `0.16` 
+**6**. **Group:** `net.openhft` **Name:** `zero-allocation-hashing` **Version:** `0.16` 
 > - **POM Project URL**: [https://github.com/OpenHFT/Zero-Allocation-Hashing](https://github.com/OpenHFT/Zero-Allocation-Hashing)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
-**8**. **Group:** `org.apache.commons` **Name:** `commons-text` **Version:** `1.10.0` 
+**7**. **Group:** `org.apache.commons` **Name:** `commons-text` **Version:** `1.10.0` 
 > - **Project URL**: [https://commons.apache.org/proper/commons-text](https://commons.apache.org/proper/commons-text)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [commons-text-1.10.0.jar/META-INF/LICENSE.txt](./third-party-dependencies/commons-text-1.10.0.jar/META-INF/LICENSE.txt) 
     - [commons-text-1.10.0.jar/META-INF/NOTICE.txt](./third-party-dependencies/commons-text-1.10.0.jar/META-INF/NOTICE.txt)
 
-**9**. **Group:** `org.apache.commons` **Name:** `commons-compress` **Version:** `1.21` 
+**8**. **Group:** `org.apache.commons` **Name:** `commons-compress` **Version:** `1.21` 
 > - **Project URL**: [https://commons.apache.org/proper/commons-compress/](https://commons.apache.org/proper/commons-compress/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [commons-compress-1.21.jar/META-INF/LICENSE.txt](./third-party-dependencies/commons-compress-1.21.jar/META-INF/LICENSE.txt) 
     - [commons-compress-1.21.jar/META-INF/NOTICE.txt](./third-party-dependencies/commons-compress-1.21.jar/META-INF/NOTICE.txt)
 
-**10**. **Group:** `org.java-websocket` **Name:** `Java-WebSocket` **Version:** `1.5.3` 
+**9**. **Group:** `org.java-websocket` **Name:** `Java-WebSocket` **Version:** `1.5.3` 
 > - **Project URL**: [https://github.com/TooTallNate/Java-WebSocket](https://github.com/TooTallNate/Java-WebSocket)
 > - **Manifest License**: "MIT License";link="https://github.com/TooTallNate/Java-WebSocket/blob/master/LICENSE" (Not Packaged)
 > - **POM License**: MIT License - [https://github.com/TooTallNate/Java-WebSocket/blob/master/LICENSE](https://github.com/TooTallNate/Java-WebSocket/blob/master/LICENSE)
 
-**11**. **Group:** `org.slf4j` **Name:** `slf4j-simple` **Version:** `1.7.30` 
+**10**. **Group:** `org.slf4j` **Name:** `slf4j-simple` **Version:** `1.7.30` 
 > - **POM Project URL**: [http://www.slf4j.org](http://www.slf4j.org)
 > - **POM License**: MIT License - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
 
-**12**. **Group:** `com.github.oshi` **Name:** `oshi-core` **Version:** `6.4.1` 
+**11**. **Group:** `com.github.oshi` **Name:** `oshi-core` **Version:** `6.4.1` 
 > - **Manifest Project URL**: [https://github.com/oshi/oshi/oshi-core](https://github.com/oshi/oshi/oshi-core)
 > - **Manifest License**: "SPDX-License-Identifier: MIT";link="https://opensource.org/licenses/MIT" (Not Packaged)
 > - **POM License**: SPDX-License-Identifier: MIT - [https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT)
 
-**13**. **Group:** `com.newrelic.agent.java` **Name:** `newrelic-api` **Version:** `8.3.0-SNAPSHOT` 
+**12**. **Group:** `com.newrelic.agent.java` **Name:** `newrelic-api` **Version:** `8.3.0-SNAPSHOT` 
 > - **POM Project URL**: [https://github.com/newrelic/newrelic-java-agent](https://github.com/newrelic/newrelic-java-agent)
 > - **POM License**: The Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [newrelic-api-8.3.0-SNAPSHOT.jar/LICENSE](./third-party-dependencies/newrelic-api-8.3.0-SNAPSHOT.jar/LICENSE)
 
-**14**. **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-databind` **Version:** `2.18.8` 
+**13**. **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-databind` **Version:** `2.18.8` 
 > - **Project URL**: [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
 > - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [jackson-databind-2.18.8.jar/META-INF/LICENSE](./third-party-dependencies/jackson-databind-2.18.8.jar/META-INF/LICENSE) 
     - [jackson-databind-2.18.8.jar/META-INF/NOTICE](./third-party-dependencies/jackson-databind-2.18.8.jar/META-INF/NOTICE)
 
-**15**. **Group:** `com.fasterxml.jackson.dataformat` **Name:** `jackson-dataformat-properties` **Version:** `2.18.8` 
-> - **Project URL**: [https://github.com/FasterXML/jackson-dataformats-text](https://github.com/FasterXML/jackson-dataformats-text)
-> - **POM License**: Apache License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-> - **POM License**: The Apache Software License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
-> - **Embedded license files**: [jackson-dataformat-properties-2.18.8.jar/META-INF/LICENSE](./third-party-dependencies/jackson-dataformat-properties-2.18.8.jar/META-INF/LICENSE) 
-    - [jackson-dataformat-properties-2.18.8.jar/META-INF/NOTICE](./third-party-dependencies/jackson-dataformat-properties-2.18.8.jar/META-INF/NOTICE)
-
-**16**. **Group:** `com.googlecode.json-simple` **Name:** `json-simple` **Version:** `1.1.1` 
+**14**. **Group:** `com.googlecode.json-simple` **Name:** `json-simple` **Version:** `1.1.1` 
 > - **POM Project URL**: [http://code.google.com/p/json-simple/](http://code.google.com/p/json-simple/)
 > - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-**17**. **Group:** `com.squareup.okhttp3` **Name:** `okhttp` **Version:** `4.10.0` 
+**15**. **Group:** `com.squareup.okhttp3` **Name:** `okhttp` **Version:** `4.10.0` 
 > - **POM Project URL**: [https://square.github.io/okhttp/](https://square.github.io/okhttp/)
 > - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [okhttp-4.10.0.jar/okhttp3/internal/publicsuffix/NOTICE](./third-party-dependencies/okhttp-4.10.0.jar/okhttp3/internal/publicsuffix/NOTICE)
 
-**18**. **Group:** `org.unbescape` **Name:** `unbescape` **Version:** `1.1.6.RELEASE` 
+**16**. **Group:** `org.unbescape` **Name:** `unbescape` **Version:** `1.1.6.RELEASE` 
 > - **Project URL**: [http://www.unbescape.org](http://www.unbescape.org)
 > - **POM License**: The Apache Software License, Version 2.0 - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 > - **Embedded license files**: [unbescape-1.1.6.RELEASE.jar/META-INF/LICENSE.txt](./third-party-dependencies/unbescape-1.1.6.RELEASE.jar/META-INF/LICENSE.txt) 

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,6 @@ subprojects {
             url 'https://oss.sonatype.org/content/repositories/snapshots/'
         }
         mavenCentral()
-        jcenter()
     }
 
     // SNAPSHOTs are considered to be "changing dependencies" and they are cached by gradle for 24 hours by default.

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -7,7 +7,6 @@ sourceCompatibility = 1.8
 repositories {
     mavenLocal()
     mavenCentral()
-    jcenter()
     maven {
         url 'https://plugins.gradle.org/m2/'
     }

--- a/instrumentation-security/build.gradle
+++ b/instrumentation-security/build.gradle
@@ -32,7 +32,7 @@ subprojects {
     dependencies {
         testImplementation(project(":instrumentation-security-test"))
         testImplementation("com.newrelic.agent.java:newrelic-api:${nrAPIVersion}")
-        testImplementation('com.fasterxml.jackson.core:jackson-databind:2.13.4')
+        testImplementation('com.fasterxml.jackson.core:jackson-databind:2.18.8')
     }
 
     test {

--- a/instrumentation-security/build.gradle
+++ b/instrumentation-security/build.gradle
@@ -32,7 +32,7 @@ subprojects {
     dependencies {
         testImplementation(project(":instrumentation-security-test"))
         testImplementation("com.newrelic.agent.java:newrelic-api:${nrAPIVersion}")
-        testImplementation('com.fasterxml.jackson.core:jackson-databind:2.18.8')
+        testImplementation('com.fasterxml.jackson.core:jackson-databind:2.18.9')
     }
 
     test {

--- a/instrumentation-security/dynamodb-1.11.390/build.gradle
+++ b/instrumentation-security/dynamodb-1.11.390/build.gradle
@@ -14,6 +14,13 @@ repositories {
     }
 }
 
+// aws-java-sdk-dynamodb 1.11.x is compiled against jackson-databind 2.6.x, which still
+// has PropertyNamingStrategy.PascalCaseStrategy. The project-wide test jackson-databind
+// bump (for CVE remediation) would otherwise win dependency resolution and break it.
+configurations.testRuntimeClasspath {
+    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-databind:2.6.7.1'
+}
+
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.security.dynamodb-1.11.390' }
 }

--- a/instrumentation-security/dynamodb-1.11.453/build.gradle
+++ b/instrumentation-security/dynamodb-1.11.453/build.gradle
@@ -14,6 +14,13 @@ repositories {
     }
 }
 
+// aws-java-sdk-dynamodb 1.11.x is compiled against jackson-databind 2.6.x, which still
+// has PropertyNamingStrategy.PascalCaseStrategy. The project-wide test jackson-databind
+// bump (for CVE remediation) would otherwise win dependency resolution and break it.
+configurations.testRuntimeClasspath {
+    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-databind:2.6.7.1'
+}
+
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.security.dynamodb-1.11.453' }
 }

--- a/instrumentation-security/dynamodb-1.11.459/build.gradle
+++ b/instrumentation-security/dynamodb-1.11.459/build.gradle
@@ -14,6 +14,13 @@ repositories {
     }
 }
 
+// aws-java-sdk-dynamodb 1.11.x is compiled against jackson-databind 2.6.x, which still
+// has PropertyNamingStrategy.PascalCaseStrategy. The project-wide test jackson-databind
+// bump (for CVE remediation) would otherwise win dependency resolution and break it.
+configurations.testRuntimeClasspath {
+    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-databind:2.6.7.1'
+}
+
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.security.dynamodb-1.11.459' }
 }

--- a/instrumentation-security/dynamodb-1.11.80/build.gradle
+++ b/instrumentation-security/dynamodb-1.11.80/build.gradle
@@ -14,6 +14,13 @@ repositories {
     }
 }
 
+// aws-java-sdk-dynamodb 1.11.x is compiled against jackson-databind 2.6.x, which still
+// has PropertyNamingStrategy.PascalCaseStrategy. The project-wide test jackson-databind
+// bump (for CVE remediation) would otherwise win dependency resolution and break it.
+configurations.testRuntimeClasspath {
+    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-databind:2.6.7.1'
+}
+
 jar {
     manifest { attributes 'Implementation-Title': 'com.newrelic.instrumentation.security.dynamodb-1.11.80' }
 }

--- a/instrumentation-security/jsp-3/build.gradle
+++ b/instrumentation-security/jsp-3/build.gradle
@@ -16,6 +16,7 @@ verifyInstrumentation {
     passesOnly('jakarta.servlet.jsp:jakarta.servlet.jsp-api:[3.0.0-M1,)') {
         implementation("jakarta.servlet:jakarta.servlet-api:5.0.0")
     }
+    excludeRegex '.*-(M|beta)[0-9]*'
 }
 
 java {

--- a/instrumentation-security/lettuce-5.0/build.gradle
+++ b/instrumentation-security/lettuce-5.0/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     implementation(project(":newrelic-security-api"))
     implementation("com.newrelic.agent.java:newrelic-api:${nrAPIVersion}")
     implementation("com.newrelic.agent.java:newrelic-weaver-api:${nrAPIVersion}")
-    implementation group: 'io.lettuce', name: 'lettuce-core', version: '5.0.3.RELEASE'
+    implementation("io.lettuce:lettuce-core:5.0.3.RELEASE")
     testImplementation('org.testcontainers:testcontainers:1.20.1')
 }
 
@@ -13,7 +13,7 @@ jar {
 }
 
 verifyInstrumentation {
-    passesOnly 'io.lettuce:lettuce-core:[5.0.0.RELEASE,6.5.0.RELEASE)'
+    passesOnly 'io.lettuce:lettuce-core:[5.0.0.RELEASE,6.8.2.RELEASE)'
     excludeRegex '.*(RC|M).*'
 }
 

--- a/instrumentation-security/lettuce-5.0/build.gradle
+++ b/instrumentation-security/lettuce-5.0/build.gradle
@@ -13,8 +13,8 @@ jar {
 }
 
 verifyInstrumentation {
-    passesOnly 'io.lettuce:lettuce-core:[5.0.0.RELEASE,6.8.2.RELEASE)'
-    excludeRegex '.*(RC|M).*'
+    passesOnly 'io.lettuce:lettuce-core:[5.0.0.RELEASE,)'
+    excludeRegex '.*(RC|M|alpha|beta)[0-9]*'
 }
 
 site {

--- a/instrumentation-security/lettuce-5.0/build.gradle
+++ b/instrumentation-security/lettuce-5.0/build.gradle
@@ -14,7 +14,7 @@ jar {
 
 verifyInstrumentation {
     passesOnly 'io.lettuce:lettuce-core:[5.0.0.RELEASE,)'
-    excludeRegex '.*(RC|M|alpha|beta)[0-9]*'
+    excludeRegex '.*(RC|M|alpha|BETA)[0-9]*'
 }
 
 site {

--- a/instrumentation-security/lettuce-5.0/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands_Instrumentation.java
+++ b/instrumentation-security/lettuce-5.0/src/main/java/io/lettuce/core/AbstractRedisAsyncCommands_Instrumentation.java
@@ -68,7 +68,7 @@ public abstract class AbstractRedisAsyncCommands_Instrumentation<K, V> {
 
     private <T> AbstractOperation preprocessSecurityHook(RedisCommand_Instrumentation<K,V,T> cmd, String methodDispatch) {
         try {
-            String type = cmd.getType().name();
+            String type = cmd.getType().toString();
             CommandArgs_Instrumentation commandArgs = cmd.getArgs();
             List<Object> arguments = new ArrayList<>();
             for(int i=0 ; i<commandArgs.count(); i++){

--- a/instrumentation-security/servlet-6.0/build.gradle
+++ b/instrumentation-security/servlet-6.0/build.gradle
@@ -13,6 +13,7 @@ jar {
 
 verifyInstrumentation {
     passesOnly 'jakarta.servlet:jakarta.servlet-api:[6.0.0,)'
+    excludeRegex '.*-(M|beta)[0-9]*'
 }
 
 java {

--- a/newrelic-security-agent/build.gradle
+++ b/newrelic-security-agent/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     shadowIntoJar ('com.googlecode.json-simple:json-simple:1.1.1'){
         exclude(module:'junit', group:'junit')
     }
-    shadowIntoJar 'com.fasterxml.jackson.core:jackson-databind:2.14.3'
+    shadowIntoJar 'com.fasterxml.jackson.core:jackson-databind:2.18.8'
     shadowIntoJar 'org.java-websocket:Java-WebSocket:1.5.3'
     shadowIntoJar 'commons-io:commons-io:2.14.0'
     shadowIntoJar 'org.apache.commons:commons-text:1.10.0'

--- a/newrelic-security-agent/build.gradle
+++ b/newrelic-security-agent/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     shadowIntoJar ('com.googlecode.json-simple:json-simple:1.1.1'){
         exclude(module:'junit', group:'junit')
     }
-    shadowIntoJar 'com.fasterxml.jackson.core:jackson-databind:2.18.8'
+    shadowIntoJar 'com.fasterxml.jackson.core:jackson-databind:2.18.9'
     shadowIntoJar 'org.java-websocket:Java-WebSocket:1.5.3'
     shadowIntoJar 'commons-io:commons-io:2.14.0'
     shadowIntoJar 'org.apache.commons:commons-text:1.10.0'

--- a/newrelic-security-agent/build.gradle
+++ b/newrelic-security-agent/build.gradle
@@ -141,6 +141,10 @@ task relocatedShadowJar(type: ShadowJar) {
             // log4j2
             "META-INF/versions/9/module-info.class",
             "META-INF/services/org.apache.logging*",
+            // jackson-core's fast-double-parser: shadow 6.0.0's bundled ASM
+            // can't parse Java 17/21 bytecode
+            "META-INF/versions/17/**",
+            "META-INF/versions/21/**",
             // asm
             "module-info.class",
             // httpclient

--- a/unittest-helper-agent/build.gradle
+++ b/unittest-helper-agent/build.gradle
@@ -8,7 +8,6 @@ plugins {
 repositories {
     mavenCentral()
     mavenLocal()
-    jcenter()
 }
 
 configurations {


### PR DESCRIPTION
## Description
1. Jackson-databind CVE remediation (CVE-2026-54512/54513, severity 9.2/9.3)
`newrelic-security-agent` bumped `jackson-databind` and `jackson-dataformat-properties` `2.14.2` → `2.18.9`.
`THIRD_PARTY_NOTICES.md` updated both `jackson` entries to include latest version details.

2. Broken build infrastructure (JCenter shutdown)
removed `jcenter()` repository declarations. `JCenter` shut down in 2021; the JVM's TLS handshake to it fails outright now, which was blocking dependency resolution for `buildSrc` (needed to fetch the shadow plugin) and other modules. Added `gradlePluginPortal()/plugins.gradle.org` maven repo where `mavenCentral()` alone didn't carry the plugin coordinates (shadow 6.0.0 was only ever published to JCenter/Plugin Portal).

3. Shadow jar build failure caused by the jackson bump
Bumping `jackson-databind` was causing build failure due to `Unsupported class file major version 61` to resolve this added excludes for `META-INF/versions/17/**` and `META-INF/versions/21/**` in the `relocatedShadowJar` task.

4. Instrumentation verification failure fixes: 
`jsp-3` and `servlet-6.0` added `excludeRegex` to exclude milestone/beta versions 
Fixed the verification error observed in lettuce-5.0 due to deprecation of a member's function and used `toString()` instead of `name().`

5. `Dynamodb` unit tests were using `jackson-databind` `2.6.x` which has `PropertyNamingStrategy.PascalCaseStrategy.` The project-wide test `jackson-databind` bump (for CVE remediation) would otherwise win dependency resolution and break it. So, forced used `2.6` version for `dynamodb` unit tests.